### PR TITLE
add geom_nop to MFSMODULES for 4k sector size hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ BSDLABEL=bsdlabel
 DOFS=${TOOLSDIR}/doFS.sh
 SCRIPTS=mdinit mfsbsd interfaces packages
 BOOTMODULES=acpi ahci
-MFSMODULES=geom_mirror opensolaris zfs ext2fs snp smbus ipmi ntfs nullfs tmpfs
+MFSMODULES=geom_mirror geom_nop opensolaris zfs ext2fs snp smbus ipmi ntfs nullfs tmpfs
 #
 COMPRESS?=	xz
 


### PR DESCRIPTION
Hi Martin,
I use geom_nop to force zfs to use ashift=12 and other people may find it useful as well mmatuska/mfsbsd#4
