### PR TITLE
Modification to support inclusion of pre-built virtio modules

### DIFF
--- a/README-Virtio.md
+++ b/README-Virtio.md
@@ -1,0 +1,19 @@
+# Building mfsbsd using virtio
+
+To build with virtio driver duringbootstrap, build kernel with
+increased NKPT, then run:
+
+    make with USER_VIRTIO=1 BUILDKERNEL=1 KERNCONF=MFSBSD
+
+To have MFSBSD kernel do following:
+
+1. create MFSBSD kernel config with "options NKPT=150".
+   see conf/MFSBSD.conf-sample for instruction to prepare kernel
+   configuration file. With options BUILDKERNEL=1 KERNCONF=MFSBSD,
+   the kernel with the kernel configuration will be built.
+
+2. Download one of virtio kernel module package from:
+	 http://people.freebsd.org/~kuriyama/virtio/
+   then extract the contents into './modules' directory.
+   (This makefile expect virtio.ko and other files in
+     ./modules/boot/modules directory)

--- a/conf/MFSBSD.conf-sample
+++ b/conf/MFSBSD.conf-sample
@@ -1,0 +1,38 @@
+Patch to increase NKPT parameter using kernel configuration file.
+
+To create amd64 based configuration file MFSBSD, do following:
+
+# cd /usr/src/sys/amd64/conf
+# cp GENERIC MFSBSD
+# patch < THIS_FILE
+
+Change 'amd64' to desired architecture if necessary.
+
+
+*** GENERIC	Tue Dec  4 12:14:17 2012
+--- MFSBSD	Sat Feb  2 19:45:56 2013
+***************
+*** 19,28 ****
+  # $FreeBSD: release/9.1.0/sys/amd64/conf/GENERIC 238090 2012-07-04 00:54:16Z delphij $
+  
+  cpu		HAMMER
+! ident		GENERIC
+  
+  makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
+  
+  options 	SCHED_ULE		# ULE scheduler
+  options 	PREEMPTION		# Enable kernel thread preemption
+  options 	INET			# InterNETworking
+--- 19,30 ----
+  # $FreeBSD: release/9.1.0/sys/amd64/conf/GENERIC 238090 2012-07-04 00:54:16Z delphij $
+  
+  cpu		HAMMER
+! ident		MFSBSD
+  
+  makeoptions	DEBUG=-g		# Build kernel with gdb(1) debug symbols
+  
++ options		NKPT=150		# Increase Number of page tables to
++ 
+  options 	SCHED_ULE		# ULE scheduler
+  options 	PREEMPTION		# Enable kernel thread preemption
+  options 	INET			# InterNETworking


### PR DESCRIPTION
Hi.

I have created a minor mod to the Makefile to copy kernel modules in module/boot/modules directory. (I used this layout because I can extract package like [this virtio modules](http://people.freebsd.org/~kuriyama/virtio/) in the modules directory directly.)

I also includes kernel configuration patch NKPT mods.
