### PR TITLE
Create zfsinstall-geli-1disk-beta

### DIFF
--- a/tools/zfsinstall-geli-1disk-beta
+++ b/tools/zfsinstall-geli-1disk-beta
@@ -1,0 +1,564 @@
+#!/bin/sh
+# $Id$
+#
+# mfsBSD ZFS install script
+# Copyright (c) 2011 Martin Matuska <mm at FreeBSD.org>
+# Modified by John Ko <mfsbsd@johnko.ca>
+# Added startblock and alignsect
+# added 4k gnop (requires kldload geom_nop)
+# to test if zpool is using 4k sectors, check "zdb | grep ashift"
+# ashift should be 12... NOT 9
+# encryption setup based on input from http://forums.freebsd.org/showthread.php?t=2775
+#
+startblock=1M
+alignsect=4k
+BOOTSIZE=500M
+FS_LIST="bootbkp tmp usr usr/ports var var/db var/db/portsnap"
+
+usage() {
+  echo "Usage: $0 [-h] -d geom_provider [-d geom_provider ...] -t archive_file [-r mirror|raidz] [-m mount_point] [-p zfs_pool_name] [-V zfs_pool_version] [-s swap_partition_size] [-z zfs_partition_size] [-c] [-l] [-g] [-e] [-4]"
+}
+
+help() {
+  echo; echo "Install FreeBSD using ZFS from a compressed archive"
+  echo; echo "Required flags:"
+  echo "-d geom_provider  : geom provider(s) to install to (e.g. da0)"
+  echo "-t archive_file   : tar archive file containing the FreeBSD distribution"
+  echo "        supported compression formats are: gzip, bzip2, xz"
+  echo; echo "Optional flags:"
+  echo "-r raidz|mirror   : select raid mode if more than one -d provider given"
+  echo "-s swap_part_size : create a swap partition with given size (default: no swap)"
+  echo "-z zfs_part_size  : create zfs parition of this size (default: all space left)"
+  echo "-p pool_name      : specify a name for the ZFS pool (default: tank)"
+  echo "-V pool_version   : specify a version number for ZFS pool (default: 13)"
+  echo "-m mount_point    : use this mount point for operations (default: /mnt)"
+  echo "-c    : enable lzjb compression for all datasets"
+  echo "-l    : use legacy mounts (via fstab) instead of ZFS mounts"
+  echo "-g    : enable use of geom_nop to emulate 4k sector size"
+  echo "-e    : enable use of geom_eli to encrypt ZFS pool (but not /bootdir)"
+  echo "        (overrides -g)"
+  echo "-4    : use fletcher4 as default checksum algorithm"
+  echo; echo "Examples:"
+  echo "Install on a single drive with 2GB swap:"
+  echo "$0 -d ad4 -s 2G"
+  echo "Install on a mirror without swap, pool name rpool:"
+  echo "$0 -d ad4 -d ad6 -r mirror -p rpool"
+  echo; echo "Notes:"
+  echo "When using swap and raidz/mirror, the swap partition is created on all drives."
+  echo "The /etc/fstab entry will contatin only the first drive's swap partition."
+  echo "You can enable all swap partitions and/or make a gmirror-ed swap later."
+}
+
+while getopts d:t:r:p:s:z:m:V:hclge4 o; do
+  case "$o" in
+          d) DEVS="$DEVS ${OPTARG##/dev/}" ;;
+          t) ARCHIVE="${OPTARG}" ;;
+          p) POOL="${OPTARG}" ;;
+          s) SWAP="${OPTARG}" ;;
+          m) MNT="${OPTARG}" ;;
+    r) RAID="${OPTARG}" ;;
+    z) ZPART="${OPTARG}" ;;
+    V) VERSION="${OPTARG}" ;;
+    c) LZJB=1 ;;
+    g) USEGNOP=1 ;;
+    e) USEGELI=1; LEGACY=1 ;;
+    l) LEGACY=1 ;;
+    4) FLETCHER=1 ;;
+    h) help; exit 1;;
+    [?]) usage; exit 1;;
+esac
+done
+
+if ! `/sbin/kldstat -m zfs >/dev/null 2>/dev/null`; then
+  /sbin/kldload zfs >/dev/null 2>/dev/null
+fi
+
+if [ "${USEGNOP}" = "1" ]; then
+  echo -n "Loading geom_nop.ko ..."
+	/sbin/kldload geom_nop > /dev/null 2> /dev/null || \
+		/sbin/kldload /root/geom_nop.ko > /dev/null 2> /dev/null || \
+		/sbin/kldload /root/bin/geom_nop.ko > /dev/null 2> /dev/null
+	/sbin/kldstat -v | /usr/bin/grep "geom_nop" > /dev/null 2> /dev/null || exit 1
+	echo " done"
+fi
+
+if [ "${USEGELI}" = "1" ]; then
+  echo -n "Loading zlib.ko ..."
+  /sbin/kldload zlib > /dev/null 2> /dev/null || \
+    /sbin/kldload /root/zlib.ko > /dev/null 2> /dev/null || \
+    /sbin/kldload /root/bin/zlib.ko > /dev/null 2> /dev/null
+  /sbin/kldstat -v | /usr/bin/grep "zlib" > /dev/null 2> /dev/null || exit 1
+  echo " done"
+  echo -n "Loading crypto.ko ..."
+  /sbin/kldload crypto > /dev/null 2> /dev/null || \
+    /sbin/kldload /root/crypto.ko > /dev/null 2> /dev/null || \
+    /sbin/kldload /root/bin/crypto.ko > /dev/null 2> /dev/null
+  /sbin/kldstat -v | /usr/bin/grep "crypto" > /dev/null 2> /dev/null || exit 1
+  echo " done"
+  echo -n "Loading geom_eli.ko ..."
+  /sbin/kldload geom_eli > /dev/null 2> /dev/null || \
+    /sbin/kldload /root/geom_eli.ko > /dev/null 2> /dev/null || \
+    /sbin/kldload /root/bin/geom_eli.ko > /dev/null 2> /dev/null
+  /sbin/kldstat -v | /usr/bin/grep "geom_eli" > /dev/null 2> /dev/null || exit 1
+  echo " done"
+fi
+
+ZFS_VERSION=`/sbin/sysctl -n vfs.zfs.version.spa 2>/dev/null`
+
+if [ -z "$ZFS_VERSION" ]; then
+        echo "Error: failed to load ZFS module"
+        exit 1
+elif [ "$ZFS_VERSION" -lt "13" ]; then
+  echo "Error: ZFS module too old, version 13 or higher required"
+  exit 1
+fi
+
+if [ -z "$DEVS" -o -z "$ARCHIVE" ]; then
+  usage
+  exit 1
+fi
+
+if [ -z "$POOL" ]; then
+  POOL=tank
+fi
+
+if [ -z "$VERSION" ]; then
+  VERSION=${ZFS_VERSION}
+elif [ "$VERSION" -gt "$ZFS_VERSION" ]; then
+  echo "Error: invalid ZFS pool version (maximum: $ZFS_VERSION)"
+  exit 1
+fi
+
+if [ "$VERSION" = "5000" ]; then
+  VERSION=
+else
+  VERSION="-o version=${VERSION}"
+fi
+
+if /sbin/zpool list $POOL > /dev/null 2> /dev/null; then
+  echo Error: ZFS pool \"$POOL\" already exists
+  echo Please choose another pool name or rename/destroy the existing pool.
+  exit 1
+fi
+
+EXPOOLS=`/sbin/zpool import | /usr/bin/grep pool: | /usr/bin/awk '{ print $2 }'`
+
+if [ -n "${EXPOOLS}" ]; then
+  for P in ${EXPOOLS}; do
+    if [ "$P" = "$POOL" ]; then
+      echo Error: An exported ZFS pool \"$POOL\" already exists
+      echo Please choose another pool name or rename/destroy the exported pool.
+      exit 1
+    fi
+  done
+fi
+
+COUNT=`echo ${DEVS} | /usr/bin/wc -w | /usr/bin/awk '{ print $1 }'`
+if [ "$COUNT" -lt "3" -a "$RAID" = "raidz" ]; then
+  echo "Error: raidz needs at least three devices (-d switch)"
+  exit 1
+elif [ "$COUNT" = "1" -a "$RAID" = "mirror" ]; then
+  echo "Error: mirror needs at least two devices (-d switch)"
+  exit 1
+elif [ "$COUNT" = "2" -a "$RAID" != "mirror" ]; then
+  echo "Notice: two drives selected, automatically choosing mirror mode"
+  RAID="mirror"
+elif [ "$COUNT" -gt "2" -a "$RAID" != "mirror" -a "$RAID" != "raidz" ]; then
+  echo "Error: please choose raid mode with the -r switch (mirror or raidz)"
+  exit 1
+fi
+
+for DEV in ${DEVS}; do
+  if ! [ -c "/dev/${DEV}" ]; then
+    echo "Error: /dev/${DEV} is not a block device"
+    exit 1
+  fi
+  if /sbin/gpart show $DEV > /dev/null 2> /dev/null; then
+    echo "Error: /dev/${DEV} already contains a partition table."
+    echo ""
+    /sbin/gpart show $DEV
+    echo "You may erase the partition table manually with the destroygeom command"
+    exit 1
+  fi
+done
+
+if ! [ -f "${ARCHIVE}" ]; then
+  echo "Error: file $ARCHIVE does not exist"
+  exit 1
+fi
+
+DIRECT_TAR=0
+FTYPE=`/usr/bin/file -b --mime-type ${ARCHIVE}`
+if [ "$FTYPE" = "application/x-tar" ]; then
+  DIRECT_TAR=1
+elif [ "$FTYPE" = "application/x-gzip" ]; then
+  EXTRACT_CMD=/usr/bin/gzip
+elif [ "$FTYPE" = "application/x-bzip2" ]; then
+  EXTRACT_CMD=/usr/bin/bzip2
+elif [ "$FTYPE" = "application/x-xz" ]; then
+  if [ ! -x "`/usr/bin/which xz`" ]; then
+    echo "xz-compressed file selected and xz is not installed";
+    exit 1
+  fi
+  EXTRACT_CMD=`which xz`
+else
+  echo "Archive must be uncompressed or gzip, bzip2 or xz compressed"
+  exit 1
+fi
+
+if [ -z "$MNT" ]; then
+  MNT=/mnt
+fi
+
+if ! [ -d "${MNT}" ]; then
+  echo "Error: $MNT is not a directory"
+  exit 1
+fi
+
+if [ -n "${ZPART}" ]; then
+  SZPART="-s ${ZPART}"
+fi
+
+if [ "${LEGACY}" = "1" ]; then
+  ALTROOT=
+  ROOTMNT=legacy
+else
+  ALTROOT="-o altroot=${MNT} -o cachefile=/boot/zfs/zpool.cache"
+  ROOTMNT=/
+fi
+
+##### Create GPT
+
+for DEV in ${DEVS}; do
+	echo -n "zpool labelclear ${DEV} ..."
+	zpool labelclear -f /dev/${DEV} > /dev/null 2> /dev/null
+	echo " done"
+  echo -n "Creating GUID partitions on ${DEV} ..."
+  if ! /sbin/gpart create -s GPT /dev/${DEV} > /dev/null; then
+    echo " error"
+    exit 1
+  fi
+  /bin/sleep 1
+  if ! echo "a 1" | /sbin/fdisk -f - ${DEV} > /dev/null 2> /dev/null; then
+    echo " error"
+    exit 1
+  fi
+  if ! /sbin/gpart add -t freebsd-boot -b ${startblock} -a ${alignsect} -s 128 ${DEV} > /dev/null; then
+    echo " error"
+    exit 1
+  fi
+  ##### boot part
+  if ! /sbin/gpart add -t freebsd-ufs -a ${alignsect} -s ${BOOTSIZE} ${DEV} > /dev/null; then
+    echo " error"
+    exit 1
+  fi
+  if [ -n "${SWAP}" ]; then
+    if ! /sbin/gpart add -t freebsd-swap -a ${alignsect} -s "${SWAP}" ${DEV} > /dev/null; then
+      echo " error"
+      exit 1
+    fi
+    SWAPPART=`/sbin/glabel status ${DEV}p3 | /usr/bin/grep gptid | /usr/bin/awk '{ print $1 }'`
+    if [ -z "$SWAPPART" ]; then
+      echo " error determining swap partition"
+    fi
+    if [ -z "$FSWAP" ]; then
+      FSWAP=${SWAPPART}
+    fi
+    ESWAP="${DEV}p3"
+  fi
+  if ! /sbin/gpart add -t freebsd-zfs -a ${alignsect} ${SZPART} ${DEV} > /dev/null; then
+    echo " error"
+    exit 1
+  fi
+  /bin/dd if=/dev/zero of=/dev/${DEV}p3 bs=512 count=560 > /dev/null 2> /dev/null
+	/sbin/zpool labelclear -f /dev/${DEV}p3 > /dev/null 2> /dev/null
+  if [ -n "${SWAP}" ]; then
+    /bin/dd if=/dev/zero of=/dev/${DEV}p4 bs=512 count=560 > /dev/null 2> /dev/null
+		/sbin/zpool labelclear -f /dev/${DEV}p4 > /dev/null 2> /dev/null
+  fi
+  echo " done"
+
+  echo -n "Configuring ZFS bootcode on ${DEV} ..."
+  # if ! /sbin/gpart bootcode -b /boot/pmbr -p /boot/gptzfsboot -i 1 ${DEV} > /dev/null; then
+  if ! /sbin/gpart bootcode -b /boot/pmbr -p /boot/gptboot -i 1 ${DEV} > /dev/null; then
+    echo " error"
+    exit 1
+  fi
+  echo " done"
+  /sbin/gpart show ${DEV}
+done
+
+##### Create zpool and zfs
+for DEV in ${DEVS}; do
+  PART=`/sbin/gpart show ${DEV} | /usr/bin/grep freebsd-zfs | /usr/bin/awk '{ print $3 }'`
+  DISKLABEL=`/sbin/glabel list ${DEV}p${PART} | /usr/bin/grep gptid | /usr/bin/awk -F"gptid/" '{ print $2 }'`
+  if [ "${USEGELI}" = "1" ]; then
+  	##### Create encrypted pool
+	  cat /dev/urandom | strings -1 | grep -o "[[:alnum:]]" | tr -d '\n' | head -c64 > /boot/${POOL}.${DISKLABEL}
+  fi
+  BOOTPART=`/sbin/gpart show ${DEV} | /usr/bin/grep freebsd-ufs | /usr/bin/awk '{ print $3 }'`
+
+  if [ -z "${PART}" ]; then
+    echo Error: freebsd-zfs partition not found on /dev/$DEV
+    exit 1
+  fi
+  BPART="${DEV}p${BOOTPART}"
+  
+	if [ "${USEGNOP}" = "1" ]; then
+  	GPART=`/sbin/glabel list ${DEV}p${PART} | /usr/bin/grep gptid | /usr/bin/awk -F"gptid/" '{ print "gptid/" $2 }'`
+  	# create 4k secttor size with gnop
+  	/sbin/gnop create -S 4096 ${GPART}
+  	GPARTS="${GPARTS}${GPART}.nop "
+  fi
+  if [ "${USEGELI}" = "1" ]; then
+		geli init -b -K /boot/${POOL}.${DISKLABEL} -e AES-XTS -s 4096 /dev/${DEV}p${PART}
+		geli attach -k /boot/${POOL}.${DISKLABEL} /dev/${DEV}p${PART}
+	  EPARTS="${EPARTS}${DEV}p${PART}.eli "
+	fi
+  PARTS="${PARTS}${DEV}p${PART} "
+done
+
+if [ "${USEGELI}" = "1" ]; then
+	##### Create encrypted pool
+	echo -n "Creating ZFS pool ${POOL} on ${PARTS}..."
+	if ! /sbin/zpool create -f -m none ${ALTROOT} ${VERSION} ${POOL} ${RAID} ${EPARTS} > /dev/null 2> /dev/null; then
+		echo " error"
+		exit 1
+	fi
+	echo " done"
+else
+	##### Create pool
+	if [ "${USEGNOP}" = "1" ]; then
+		echo -n "Creating ZFS pool ${POOL} on ${GPARTS}..."
+		if ! /sbin/zpool create -f -m none ${ALTROOT} ${VERSION} ${POOL} ${RAID} ${GPARTS} > /dev/null 2> /dev/null; then
+			echo " error"
+			exit 1
+		fi
+		echo " done"
+	else
+		echo -n "Creating ZFS pool ${POOL} on ${PARTS}..."
+		if ! /sbin/zpool create -f -m none ${ALTROOT} ${VERSION} ${POOL} ${RAID} ${PARTS} > /dev/null 2> /dev/null; then
+			echo " error"
+			exit 1
+		fi
+		echo " done"
+	fi
+fi
+
+if [ "${FLETCHER}" = "1" ]; then
+  echo -n "Setting default checksum to fletcher4 for ${POOL} ..."
+  if ! /sbin/zfs set checksum=fletcher4 ${POOL} > /dev/null 2> /dev/null; then
+    echo " error"
+    exit 1
+  fi
+  echo " done"
+fi
+
+if [ "${LZJB}" = "1" ]; then
+  echo -n "Setting default compression to lzjb for ${POOL} ..."
+  if ! /sbin/zfs set compression=lzjb ${POOL} > /dev/null 2> /dev/null; then
+    echo " error"
+    exit 1
+  fi
+  echo " done"
+fi
+
+echo -n "Creating ${POOL} root partition:"
+if ! /sbin/zfs create -o mountpoint=${ROOTMNT} ${POOL}/root > /dev/null 2> /dev/null; then
+  echo " error"
+  exit 1
+fi
+echo " ... done"
+echo -n "Creating ${POOL} partitions:"
+for FS in ${FS_LIST}; do
+  if [ "${LEGACY}" = "1" ]; then
+    MNTPT="-o mountpoint=legacy"
+  else
+    MNTPT=
+  fi
+  if ! /sbin/zfs create ${MNTPT} ${POOL}/root/${FS} > /dev/null 2> /dev/null; then
+    echo " error"
+    exit 1
+  fi
+  echo -n " ${FS}"
+done
+echo " ... done"
+echo -n "Setting bootfs for ${POOL} to ${POOL}/root ..."
+if ! /sbin/zpool set bootfs=${POOL}/root ${POOL} > /dev/null 2> /dev/null; then
+  echo " error"
+  exit 1
+fi
+echo " done"
+/sbin/zfs list -r ${POOL}
+
+##### Mount and populate zfs (if legacy)
+if [ "${LEGACY}" = "1" ]; then
+  echo -n "Mounting ${POOL} on ${MNT} ..."
+  /bin/mkdir -p ${MNT}
+  if ! /sbin/mount -t zfs ${POOL}/root ${MNT} > /dev/null 2> /dev/null; then
+    echo " error mounting pool/root"
+    exit 1
+  fi
+  for FS in ${FS_LIST}; do
+    /bin/mkdir -p ${MNT}/${FS}
+    if ! /sbin/mount -t zfs ${POOL}/root/${FS} ${MNT}/${FS} > /dev/null 2> /dev/null; then
+      echo " error mounting ${POOL}/root/${FS}"
+      exit 1
+    fi
+  done
+echo " done"
+fi
+
+
+##### Create /bootdir
+echo -n "Creating /bootdir on${BPARTS} ..."
+/sbin/newfs -n /dev/${BPART} > /dev/null 2> /dev/null || exit 1
+if [ ! -e ${MNT}/bootdir ]; then
+  /bin/mkdir ${MNT}/bootdir
+fi
+/sbin/mount /dev/${BPART} ${MNT}/bootdir || exit 1
+echo " done"
+
+
+echo -n "Extracting FreeBSD distribution ..."
+if [ "${DIRECT_TAR}" = "1" ]; then
+  if ! /usr/bin/tar -C ${MNT} -x -f ${ARCHIVE} > /dev/null 2> /dev/null; then
+    echo " error"
+    exit 1
+  fi
+else
+  if ! ${EXTRACT_CMD} -d -c ${ARCHIVE} | /usr/bin/tar -C ${MNT} -x -f - > /dev/null 2> /dev/null; then
+    echo " error"
+    exit 1
+  fi
+fi
+echo " done"
+
+##### Adjust configuration files
+
+echo -n "Writing /boot/loader.conf ..."
+cat >>${MNT}/boot/loader.conf <<EOF
+zfs_load="YES"
+vfs.root.mountfrom="ufs:${BPART}"
+vfs.root.mountfrom="zfs:${POOL}/root"
+EOF
+echo " done"
+
+if [ "${USEGELI}" = "1" ]; then
+##### backup key and metadata
+/bin/cp -pv /boot/${POOL}.${DISKLABEL} ${MNT}/boot/ || exit 1
+/bin/cp -pv /var/backups/* ${MNT}/var/backups/ || exit 1
+cat >>${MNT}/boot/loader.conf <<EOF
+aesni_load="YES"
+geom_eli_load="YES"
+EOF
+cat >>${MNT}/etc/rc.conf <<EOF
+geli_swap_flags="-e AES-XTS -l 256 -s 4096 -d"
+EOF
+for a in ${PARTS}
+do
+cat >>${MNT}/boot/loader.conf <<EOF
+geli_${a}_keyfile0_load="YES"
+geli_${a}_keyfile0_type="${a}:geli_keyfile0"
+geli_${a}_keyfile0_name="/boot/${POOL}.${DISKLABEL}"
+EOF
+done
+fi
+
+##### Write fstab if swap or legacy
+echo -n "Writing /etc/fstab ..."
+rm -f ${MNT}/etc/fstab
+touch ${MNT}/etc/fstab
+if [ -n "${FSWAP}" -o "${LEGACY}" = "1" ]; then
+  if [ "${USEGELI}" = "1" ]; then
+    echo "/dev/${ESWAP}.eli none swap sw 0 0" > ${MNT}/etc/fstab
+  else
+    if [ -n "${FSWAP}" ]; then
+      echo "/dev/${FSWAP} none swap sw 0 0" > ${MNT}/etc/fstab
+    fi
+  fi
+  if [ "${LEGACY}" = "1" ]; then
+    for FS in ${FS_LIST}; do
+      echo ${POOL}/root/${FS} /${FS} zfs rw 0 0 >> ${MNT}/etc/fstab
+    done
+  fi
+fi
+echo /dev/${BPART} /bootdir ufs rw 0 0 >> ${MNT}/etc/fstab
+echo " done"
+if [ "${LEGACY}" != "1" ]; then
+  echo -n "Writing /etc/rc.conf ..."
+  echo 'zfs_enable="YES"' >> ${MNT}/etc/rc.conf
+  echo " done"
+fi
+
+echo -n "Copying /boot/zfs/zpool.cache ..."
+if [ -n "${LEGACY}" ]; then
+  for FS in ${FS_LIST}; do
+    /sbin/umount ${MNT}/${FS} > /dev/null 2> /dev/null
+  done
+  /sbin/umount ${MNT} > /dev/null 2> /dev/null
+fi
+if ! /sbin/umount ${MNT}/bootdir > /dev/null 2> /dev/null; then
+  echo " error umounting /bootdir"
+  exit 1
+fi
+if ! /sbin/zpool export ${POOL} > /dev/null 2> /dev/null; then
+  echo " error exporting pool"
+  exit 1
+fi
+if ! /sbin/zpool import ${ALTROOT} ${POOL} > /dev/null 2> /dev/null; then
+  echo " error importing pool"
+  exit 1
+fi
+if [ -n "${LEGACY}" ]; then
+  if ! /sbin/mount -t zfs ${POOL}/root ${MNT} > /dev/null 2> /dev/null; then
+    echo " error mounting ${POOL}/root"
+    exit 1
+  fi
+fi
+if ! /sbin/mount /dev/${BPART} ${MNT}/bootdir; then
+  echo " error remounting /bootdir"
+  exit 1
+fi
+if ! /bin/cp /boot/zfs/zpool.cache ${MNT}/boot/zfs/ > /dev/null 2> /dev/null; then
+  echo " error copying zpool.cache"
+  exit 1
+fi
+if [ -n "${LEGACY}" ]; then
+  for FS in ${FS_LIST}; do
+    if ! /sbin/mount -t zfs ${POOL}/root/${FS} ${MNT}/${FS} > /dev/null 2> /dev/null; then
+      echo " error mounting ${POOL}/root/${FS}"
+      exit 1
+    fi
+  done
+fi
+echo " done"
+
+echo -n "Linking /bootdir ..."
+cd ${MNT}
+/bin/mv boot bootdir/ || exit 1
+/bin/ln -s bootdir/boot ${MNT}/boot || exit 1
+/bin/chflags -h sunlink ${MNT}/boot || exit 1
+echo " done"
+
+/bin/cp -RpP ${MNT}/bootdir/ ${MNT}/bootbkp/ || exit 1
+
+echo -n "Generating /boot sha256 hash ..."
+/usr/bin/find ${MNT}/boot/ -type f -exec /sbin/sha256 {} \; | sed "s|${MNT}||g" | sort > ${MNT}/etc/boot.sha256
+echo " done"
+
+##### Mount devfs for post-configuration
+
+if ! /sbin/mount -t devfs devfs ${MNT}/dev; then
+  echo "Error mounting devfs on ${MNT}/dev"
+fi
+
+echo ""
+echo "Installation complete."
+echo "The system will boot from ZFS with clean install on next reboot"
+echo ""
+echo "You may type \"chroot ${MNT}\" and make any adjustments you need."
+echo "For example, change the root password or edit/create /etc/rc.conf for"
+echo "for system services. "
+echo ""
+echo "WARNING - Don't export ZFS pool \"${POOL}\"!"


### PR DESCRIPTION
Here's a mod of mmatuska's zfsinstall to use GELI (and optionally GNOP without GELI to force set zpool ashift=12)

Issues:
- install 1 disk only, use zfsinstall-adddisk-geli-beta to add zpool mirror disk after.
- do not shuffle the physical disks, must keep the disk in same boot order (ada0 ada1)
- requires geom_nop.ko, zlib.ko, crypto.ko, geom_eli.ko

Passwordless GELI (unsecure):
- add "-P" right after "geli init"
- add "-p" right after "geli attach"
