### PR TITLE
Create zfsinstall-adddisk-geli-beta

### DIFF
--- a/tools/zfsinstall-adddisk-geli-beta
+++ b/tools/zfsinstall-adddisk-geli-beta
@@ -32,7 +32,7 @@ DISK=${1}
 if [ -z ${DISK} ]; then
   echo    "usage:    ${0##*/} device"
   echo -n "devices:  "
-  ~/bin/bsd-list-hdd.sh 2>/dev/null | tr "\n" " "
+  ls -1 /dev/ | egrep ".{0,1}da[0-9]" | egrep -v "[0-9]p[0-9]" 2>/dev/null | tr "\n" " "
   echo
   exit 1
 else


### PR DESCRIPTION
This script helps user add a mirror disk to a root pool that was installed with zfsinstall-geli-1disk-beta

Issues:
- must edit the script to match the settings used during zfsinstall-geli-1disk-beta
- do not shuffle the physical disks, must keep the disk in same boot order (ada0 ada1)
- requires geom_nop.ko, zlib.ko, crypto.ko, geom_eli.ko

Passwordless GELI (unsecure):
- add "-P" right after "geli init"
- add "-p" right after "geli attach"
