### PR TITLE
Fix mac_interfaces use in loader.conf.

### DIFF
--- a/scripts/mfsbsd
+++ b/scripts/mfsbsd
@@ -78,7 +78,7 @@ mfsbsd_start()
         fi
 	if [ -n "$_ns" ]; then
 		for n in $_ns; do
-			echo "nameserver $_n" >> /etc/resolv.conf
+			echo "nameserver $n" >> /etc/resolv.conf
 		done
 	fi
 }


### PR DESCRIPTION
This change fixes the code in mfsbsd that expands the
mfsbsd.mac_interfaces variable set in loader.conf. Aside from a typo
that looked at cloned_interfaces, there was also the issue of
correctly quoting $i so that it expands $i rather than $i_mac.
