### PR TITLE
Add missing modules for bsdinstall-based zfsroot/geli.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ BSDLABEL=bsdlabel
 DOFS=${TOOLSDIR}/doFS.sh
 SCRIPTS=mdinit mfsbsd interfaces packages
 BOOTMODULES=acpi ahci
-MFSMODULES=geom_mirror geom_nop opensolaris zfs ext2fs snp smbus ipmi ntfs nullfs tmpfs
+MFSMODULES=geom_mirror geom_nop opensolaris zfs ext2fs snp smbus ipmi ntfs nullfs tmpfs \
+	crypto cryptodev geom_eli
 #
 
 .if !defined(ARCH)


### PR DESCRIPTION
Add missing modules for enabling bsdinstall-based ZFS-on-root with optional GELI installations.
