### PR TITLE
Allow CFGDIR to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ MFSROOT_MAXSIZE?=64m
 # Paths
 #
 SRC_DIR?=/usr/src
-CFGDIR=conf
+CFGDIR?=conf
 SCRIPTSDIR=scripts
 PACKAGESDIR?=packages
 CUSTOMFILESDIR=customfiles


### PR DESCRIPTION
Allow CFGDIR to be overridden when calling make, useful when automating mfsbsd builds in some situation.