### PR TITLE
doFS: use the apparent size instead of the disk usage

### DIFF
--- a/tools/doFS.sh
+++ b/tools/doFS.sh
@@ -24,7 +24,7 @@ FSLABEL=$1 ; shift
 if [ ${FSSIZE} -eq 0 -a ${FSLABEL} = "auto" ]; then
 	roundup() echo $((($1+$2-1)-($1+$2-1)%$2))
 	nf=$(find ${FSPROTO} |wc -l)
-	sk=$(du -sk ${FSPROTO} |cut -f1)
+	sk=$(du -skA ${FSPROTO} |cut -f1)
 	FSINODE=$(roundup $(($sk*1024/$nf)) ${FSINODE})
 	FSSIZE=$(roundup $(($sk*12/10)) 1024)
 fi


### PR DESCRIPTION
Using the disk size can lead to errors, as it seems like it takes some time 
for it to be the real file size (at least when using ZFS). As an example, 
here is the size of mfsroot.gz just after it's created and then after 1s:

28705	/root/mfsbsd/tmp/disk/mfsroot.gz
sleep 1;
31401	/root/mfsbsd/tmp/disk/mfsroot.gz

In order to solve this, use the apparent size instead of the disk size.