### PR TITLE
Put both /var/{db,cache}/pkg in tmpfs.

### DIFF
--- a/scripts/mdinit
+++ b/scripts/mdinit
@@ -24,6 +24,9 @@ mdinit_start()
 		/sbin/mount -t tmpfs tmpfs /usr
 		/rescue/gzip -d -c /.usr.tar.gz | /rescue/tar -x -C / -f -
 	fi
+	/sbin/mount -t tmpfs /var/db/pkg
+	mkdir -p /var/cache/pkg
+	/sbin/mount -t tmpfs /var/cache/pkg
 }
 
 load_rc_config $name


### PR DESCRIPTION
The default root-in-mfs configuration is too small to bootstrap `pkg(8)` because the sqlite file is 45 MB.  Both directories can be pushed in `tmpfs` instead.