### PR TITLE
fix serial console (add boot.config and device.hints to image)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,7 +456,8 @@ ${WRKDIR}/.boot_done:
 	${_v}${MKDIR} ${WRKDIR}/disk/boot && ${CHOWN} root:wheel ${WRKDIR}/disk
 	${_v}${RM} -f ${_BOOTDIR}/kernel/kernel.debug
 	${_v}${CP} -rp ${_BOOTDIR}/kernel ${WRKDIR}/disk/boot
-.for FILE in boot defaults loader loader.help *.rc *.4th
+	${_v}${CP} -rp ${_DESTDIR}/boot.config ${WRKDIR}/disk
+.for FILE in boot defaults device.hints loader loader.help *.rc *.4th
 	${_v}${CP} -rp ${_DESTDIR}/boot/${FILE} ${WRKDIR}/disk/boot
 .endfor
 	${_v}${RM} -rf ${WRKDIR}/disk/boot/kernel/*.ko ${WRKDIR}/disk/boot/kernel/*.symbols


### PR DESCRIPTION
fix serial console by adding /boot.config and /boot/device.hints to the image. previously these files were only added to the mfsroot(.gz) where they could not have been seen by the boot loaders.