### PR TITLE
Allow variable overrides.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,12 @@
 #
 # User-defined variables
 #
-BASE?=/cdrom/usr/freebsd-dist
+#BASE?=/cdrom/usr/freebsd-dist
+BASE=/image
 KERNCONF?= GENERIC
 MFSROOT_FREE_INODES?=10%
 MFSROOT_FREE_BLOCKS?=10%
-MFSROOT_MAXSIZE?=80m
+MFSROOT_MAXSIZE?=100m
 
 # If you want to build your own kernel and make you own world, you need to set
 # -DCUSTOM or CUSTOM=1
@@ -39,7 +40,8 @@ CUSTOMFILESDIR?=customfiles
 TOOLSDIR?=	tools
 PRUNELIST?=	${TOOLSDIR}/prunelist
 KERN_EXCLUDE?=	${TOOLSDIR}/kern_exclude
-PKG_STATIC?=	${TOOLSDIR}/pkg-static
+#PKG_STATIC?=	${TOOLSDIR}/pkg-static
+PKG_STATIC?=	$(which pkg_static)
 #
 # Program defaults
 #

--- a/Makefile
+++ b/Makefile
@@ -468,6 +468,8 @@ ${WRKDIR}/.boot_done:
 .if defined(DEBUG)
 	${_v}-${INSTALL} -m 0555 ${_BOOTDIR}/${KERNDIR}/kernel.symbols ${WRKDIR}/disk/boot/kernel
 .endif
+	# Install modules need to boot into the kernel directory
+	${_v}${FIND} ${_BOOTDIR}/${KERNDIR} -name 'acpi*.ko' -exec ${INSTALL} -m 0555 {} ${WRKDIR}/disk/boot/kernel \;
 .for FILE in ${BOOTMODULES}
 	${_v}[ ! -f ${_BOOTDIR}/${KERNDIR}/${FILE}.ko ] || \
 		${INSTALL} -m 0555 ${_BOOTDIR}/${KERNDIR}/${FILE}.ko ${WRKDIR}/disk/boot/kernel

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ BSDLABEL?=	bsdlabel
 DOFS?=		${TOOLSDIR}/doFS.sh
 SCRIPTS?=	mdinit mfsbsd interfaces packages
 BOOTMODULES?=	acpi ahci
+BOOTFILES?=	boot defaults device.hints loader loader.help *.rc *.4th
 MFSMODULES?=	geom_mirror geom_nop opensolaris zfs ext2fs snp smbus ipmi ntfs nullfs tmpfs \
 	aesni crypto cryptodev geom_eli
 # Sometimes the kernel is compiled with a different destination.
@@ -460,8 +461,8 @@ ${WRKDIR}/.boot_done:
 	${_v}${CHOWN} root:wheel ${WRKDIR}/disk
 	${_v}${TAR} -cf -  -X ${KERN_EXCLUDE} -C ${_BOOTDIR}/${KERNDIR} . | ${TAR} -xvf - -C ${WRKDIR}/disk/boot/kernel
 	${_v}${CP} -rp ${_DESTDIR}/boot.config ${WRKDIR}/disk
-.for FILE in boot defaults device.hints loader loader.help *.rc *.4th
-	${_v}${CP} -rp ${_DESTDIR}/boot/${FILE} ${WRKDIR}/disk/boot
+.for FILE in ${BOOTFILES}
+	${_v}-${CP} -rp ${_DESTDIR}/boot/${FILE} ${WRKDIR}/disk/boot
 .endfor
 	${_v}${RM} -rf ${WRKDIR}/disk/boot/kernel/*.ko ${WRKDIR}/disk/boot/kernel/*.symbols
 .if defined(DEBUG)

--- a/Makefile
+++ b/Makefile
@@ -31,56 +31,55 @@ MFSROOT_MAXSIZE?=80m
 #
 # Paths
 #
-SRC_DIR?=/usr/src
-CFGDIR?=conf
-SCRIPTSDIR=scripts
-PACKAGESDIR?=packages
-CUSTOMFILESDIR=customfiles
-TOOLSDIR=tools
-PRUNELIST?=${TOOLSDIR}/prunelist
-PKG_STATIC?=${TOOLSDIR}/pkg-static
+SRC_DIR?=	/usr/src
+CFGDIR?=	conf
+SCRIPTSDIR?=	scripts
+PACKAGESDIR?=	packages
+CUSTOMFILESDIR?=customfiles
+TOOLSDIR?=	tools
+PRUNELIST?=	${TOOLSDIR}/prunelist
+PKG_STATIC?=	${TOOLSDIR}/pkg-static
 #
 # Program defaults
 #
-MKDIR=/bin/mkdir -p
-CHOWN=/usr/sbin/chown
-CAT=/bin/cat
-PWD=/bin/pwd
-TAR=/usr/bin/tar
-GTAR=/usr/local/bin/gtar
-CP=/bin/cp
-MV=/bin/mv
-RM=/bin/rm
-RMDIR=/bin/rmdir
-CHFLAGS=/bin/chflags
-GZIP=/usr/bin/gzip
-TOUCH=/usr/bin/touch
-INSTALL=/usr/bin/install
-LS=/bin/ls
-LN=/bin/ln
-FIND=/usr/bin/find
-PW=/usr/sbin/pw
-SED=/usr/bin/sed
-UNAME=/usr/bin/uname
-BZIP2=/usr/bin/bzip2
-XZ=/usr/bin/xz
-MAKEFS=/usr/sbin/makefs
-MKISOFS=/usr/local/bin/mkisofs
-SSHKEYGEN=/usr/bin/ssh-keygen
-SYSCTL=/sbin/sysctl
-PKG=/usr/local/sbin/pkg
+MKDIR?=		/bin/mkdir -p
+CHOWN?=		/usr/sbin/chown
+CAT?=		/bin/cat
+PWD?=		/bin/pwd
+TAR?=		/usr/bin/tar
+GTAR?=		/usr/local/bin/gtar
+CP?=		/bin/cp
+MV?=		/bin/mv
+RM?=		/bin/rm
+RMDIR?=		/bin/rmdir
+CHFLAGS?=	/bin/chflags
+GZIP?=		/usr/bin/gzip
+TOUCH?=		/usr/bin/touch
+INSTALL?=	/usr/bin/install
+LS?=		/bin/ls
+LN?=		/bin/ln
+FIND?=		/usr/bin/find
+PW?=		/usr/sbin/pw
+SED?=		/usr/bin/sed
+UNAME?=		/usr/bin/uname
+BZIP2?=		/usr/bin/bzip2
+XZ?=		/usr/bin/xz
+MAKEFS?=	/usr/sbin/makefs
+MKISOFS?=	/usr/local/bin/mkisofs
+SSHKEYGEN?=	/usr/bin/ssh-keygen
+SYSCTL?=	/sbin/sysctl
+PKG?=		/usr/local/sbin/pkg
 #
 CURDIR!=${PWD}
-WRKDIR?=${CURDIR}/tmp
+WRKDIR?=	${CURDIR}/tmp
 #
-BSDLABEL=bsdlabel
+BSDLABEL?=	bsdlabel
 #
-DOFS=${TOOLSDIR}/doFS.sh
-SCRIPTS=mdinit mfsbsd interfaces packages
-BOOTMODULES=acpi ahci
-MFSMODULES=geom_mirror geom_nop opensolaris zfs ext2fs snp smbus ipmi ntfs nullfs tmpfs \
+DOFS?=		${TOOLSDIR}/doFS.sh
+SCRIPTS?=	mdinit mfsbsd interfaces packages
+BOOTMODULES?=	acpi ahci
+MFSMODULES?=	geom_mirror geom_nop opensolaris zfs ext2fs snp smbus ipmi ntfs nullfs tmpfs \
 	aesni crypto cryptodev geom_eli
-#
 
 .if defined(V)
 _v=
@@ -97,7 +96,7 @@ TARGET=		${ARCH}
 .endif
 
 .if !defined(RELEASE)
-RELEASE!=${UNAME} -r
+RELEASE!=	${UNAME} -r
 .endif
 
 .if !defined(SE)
@@ -106,35 +105,35 @@ IMAGE_PREFIX?=	mfsbsd
 IMAGE_PREFIX?=	mfsbsd-se
 .endif
 
-IMAGE?=	${IMAGE_PREFIX}-${RELEASE}-${TARGET}.img
-ISOIMAGE?= ${IMAGE_PREFIX}-${RELEASE}-${TARGET}.iso
-TARFILE?= ${IMAGE_PREFIX}-${RELEASE}-${TARGET}.tar
-GCEFILE?= ${IMAGE_PREFIX}-${RELEASE}-${TARGET}.tar.gz
-_DISTDIR= ${WRKDIR}/dist/${RELEASE}-${TARGET}
+IMAGE?=		${IMAGE_PREFIX}-${RELEASE}-${TARGET}.img
+ISOIMAGE?=	${IMAGE_PREFIX}-${RELEASE}-${TARGET}.iso
+TARFILE?=	${IMAGE_PREFIX}-${RELEASE}-${TARGET}.tar
+GCEFILE?=	${IMAGE_PREFIX}-${RELEASE}-${TARGET}.tar.gz
+_DISTDIR=	${WRKDIR}/dist/${RELEASE}-${TARGET}
 
 .if !defined(DEBUG)
-EXCLUDE=--exclude *.symbols
+EXCLUDE=	--exclude *.symbols
 .else
 EXCLUDE=
 .endif
 
 # Roothack stuff
 .if defined(ROOTHACK_FILE) && exists(${ROOTHACK_FILE})
-ROOTHACK=1
+ROOTHACK=	1
 ROOTHACK_PREBUILT=1
-_ROOTHACK_FILE=${ROOTHACK_FILE}
+_ROOTHACK_FILE=	${ROOTHACK_FILE}
 .else
-_ROOTHACK_FILE=${WRKDIR}/roothack/roothack
+_ROOTHACK_FILE=	${WRKDIR}/roothack/roothack
 .endif
 
 # Check if we are installing FreeBSD 9 or higher
 .if exists(${BASE}/base.txz) && exists(${BASE}/kernel.txz)
-FREEBSD9?=yes
-BASEFILE?=${BASE}/base.txz
-KERNELFILE?=${BASE}/kernel.txz
+FREEBSD9?=	yes
+BASEFILE?=	${BASE}/base.txz
+KERNELFILE?=	${BASE}/kernel.txz
 .else
-BASEFILE?=${BASE}/base/base.??
-KERNELFILE?=${BASE}/kernels/generic.??
+BASEFILE?=	${BASE}/base/base.??
+KERNELFILE?=	${BASE}/kernels/generic.??
 .endif
 
 .if defined(MAKEJOBS)

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,7 @@ SSHKEYGEN?=	/usr/bin/ssh-keygen
 SYSCTL?=	/sbin/sysctl
 PKG?=		/usr/local/sbin/pkg
 #
-CURDIR!=${PWD}
-WRKDIR?=	${CURDIR}/tmp
+WRKDIR?=	${.CURDIR}/work
 #
 BSDLABEL?=	bsdlabel
 #
@@ -545,7 +544,7 @@ ${GCEFILE}:
 .if !exists(${GTAR})
 	${_v}echo "${GTAR} is missing, please install archivers/gtar first"; exit 1
 .else
-	${_v}${GTAR} -C ${CURDIR} -Szcf ${GCEFILE} --transform='s/${IMAGE}/disk.raw/' ${IMAGE}
+	${_v}${GTAR} -C ${.CURDIR} -Szcf ${GCEFILE} --transform='s/${IMAGE}/disk.raw/' ${IMAGE}
 	@echo " GCE tarball built"
 	${_v}${LS} -l ${GCEFILE}
 .endif
@@ -569,7 +568,7 @@ tar: install prune config customfiles boot compress-usr mfsroot fbsddist ${TARFI
 ${TARFILE}:
 	@echo -n "Creating tar file ..."
 	${_v}cd ${WRKDIR}/disk && ${FIND} . -depth 1 \
-		-exec ${TAR} -r -f ${CURDIR}/${TARFILE} {} \;
+		-exec ${TAR} -r -f ${.CURDIR}/${TARFILE} {} \;
 	@echo " done"
 	${_v}${LS} -l ${TARFILE}
 

--- a/tools/do_gpt.sh
+++ b/tools/do_gpt.sh
@@ -60,8 +60,14 @@ if [ -n "$VERBOSE" ]; then
 else
   TIME=
 fi
+
 gpart create -s gpt ${unit}
+set +e
 gpart add -t freebsd-boot -b 34 -l boot -s 512K ${unit}
+if [ $? != 0 ]; then
+	gpart add -t freebsd-boot -l boot -s 512K ${unit}
+fi
+set -e
 gpart bootcode -b ${BOOTDIR}/pmbr -p ${BOOTDIR}/gptboot -i 1 ${unit}
 gpart add -t freebsd-ufs -l rootfs ${unit}
 

--- a/tools/kern_exclude
+++ b/tools/kern_exclude
@@ -1,0 +1,3 @@
+kernel.debug
+*.symbols
+*.ko


### PR DESCRIPTION
This combines a few fixes / cleanups.

First allow variables to be overridden by .including a separate makefile that can have custom settings.

Use KERNDIR so the custom build can pull the kernel from a directory other than /boot/kernel

Use exclude option to tar to not extract unwanted files.

Install all acpi*ko modules to the boot image.
