### PR TITLE
Fix gpart

### DIFF
--- a/tools/do_gpt.sh
+++ b/tools/do_gpt.sh
@@ -61,7 +61,7 @@ else
   TIME=
 fi
 gpart create -s gpt ${unit}
-gpart add -t freebsd-boot -b 34 -l boot -s 512K ${unit}
+gpart add -t freebsd-boot -l boot -s 512K ${unit}
 gpart bootcode -b ${BOOTDIR}/pmbr -p ${BOOTDIR}/gptboot -i 1 ${unit}
 gpart add -t freebsd-ufs -l rootfs ${unit}
 

--- a/tools/zfsinstall
+++ b/tools/zfsinstall
@@ -215,7 +215,7 @@ for DEV in ${DEVS}; do
 		echo " error"
 		exit 1
 	fi
-	if ! /sbin/gpart add -t freebsd-boot -s 128 ${DEV} > /dev/null; then
+	if ! /sbin/gpart add -t freebsd-boot -s 512K ${DEV} > /dev/null; then
 		echo " error"
 		exit 1
 	fi


### PR DESCRIPTION
This patches fix two gpart related issues when using mfsbsd with newer versions of FreeBSD. Each change has it's own description. Those issues prevent using mfsbsd or zfsinstall.

Thanks, Roger.