### PR TITLE
Corrected reference to pkg-static and increased image size to 90m.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BASE?=/cdrom/usr/freebsd-dist
 KERNCONF?= GENERIC
 MFSROOT_FREE_INODES?=10%
 MFSROOT_FREE_BLOCKS?=10%
-MFSROOT_MAXSIZE?=80m
+MFSROOT_MAXSIZE?=90m
 
 # If you want to build your own kernel and make you own world, you need to set
 # -DCUSTOM or CUSTOM=1
@@ -35,7 +35,7 @@ PACKAGESDIR?=packages
 CUSTOMFILESDIR=customfiles
 TOOLSDIR=tools
 PRUNELIST?=${TOOLSDIR}/prunelist
-PKG_STATIC?=${TOOLSDIR}/pkg-static
+PKG_STATIC?=/usr/local/sbin/pkg-static
 #
 # Program defaults
 #


### PR DESCRIPTION
Minor fixes.
The 'pkg-static' executable is not included in the tools directory, thus the Makefile was referring to a non-existent tool. Also, FreeBSD 11.1 seems to require a larger image (90m works).