### PR TITLE
Fix the roothack build

### DIFF
--- a/tools/roothack/Makefile
+++ b/tools/roothack/Makefile
@@ -1,7 +1,7 @@
 PROG=	roothack
 MAN=
 
-LDADD=	-larchive -lbz2 -lz -llzma -lcrypto -lbsdxml
+LDADD=	-larchive -lbz2 -lz -llzma -lcrypto -lbsdxml -lmd
 
 NO_SHARED=
 


### PR DESCRIPTION
CURRENT as of r362452 and STABLE as of r36291 need to link against libmd, as will the upcoming 12.2 and 13.0 releases.

This fixes the issue raised in #111.