### PR TITLE
This commit adds EFI boot support to mfsBSD.

### DIFF
--- a/mini/Makefile
+++ b/mini/Makefile
@@ -92,6 +92,8 @@ TARFILE?= ${IMAGE_PREFIX}-${RELEASE}-${TARGET}.tar
 GCEFILE?= ${IMAGE_PREFIX}-${RELEASE}-${TARGET}.tar.gz
 _DISTDIR= ${WRKDIR}/dist/${RELEASE}-${TARGET}
 
+EFISP?= ../work/efisp.img
+
 .if !defined(DEBUG)
 EXCLUDE=--exclude *.symbols
 .else
@@ -272,7 +274,7 @@ ${IMAGE}:
 	${_v}${RM} -rf ${WRKDIR}/mnt ${WRKDIR}/trees
 	${_v}${MV} ${WRKDIR}/disk.img ${.TARGET}
 .else
-	${_v}${TOOLSDIR}/do_gpt.sh ${.TARGET} ${WRKDIR}/disk 0 ${BASEDIR}/boot ${VERB}
+	${_v}${TOOLSDIR}/do_gpt.sh ${.TARGET} ${WRKDIR}/disk 0 ${BASEDIR}/boot ${EFISP} ${VERB}
 .endif
 	@echo " done"
 	${_v}${LS} -l ${.TARGET}
@@ -291,7 +293,7 @@ ${GCEFILE}:
 iso: install config boot mfsroot ${ISOIMAGE}
 ${ISOIMAGE}:
 	${_v}echo -n "Creating ISO image ..."
-	${_v}${MAKEFS} -t cd9660 -o rockridge,bootimage=i386\;/boot/cdboot,no-emul-boot,label=mfsBSD ${ISOIMAGE} ${WRKDIR}/disk
+	${_v}${MAKEFS} -t cd9660 -o rockridge,label=mfsBSD -o bootimage=i386\;/boot/cdboot,no-emul-boot -o bootimage=i386\;${EFISP},no-emul-boot,platformid=efi ${ISOIMAGE} ${WRKDIR}/disk
 	${_v}echo " done"
 	${_v}${LS} -l ${ISOIMAGE}
 

--- a/tools/do_gpt.sh
+++ b/tools/do_gpt.sh
@@ -6,7 +6,8 @@ FSIMG=$1
 FSPROTO=$2
 FSSIZE=$3
 BOOTDIR=$4
-VERBOSE=$5
+EFIESP=$5
+VERBOSE=$6
 
 FSLABEL="auto"
 
@@ -64,10 +65,13 @@ fi
 gpart create -s gpt ${unit}
 gpart add -t freebsd-boot -b 40 -l boot -s 472 ${unit}
 gpart bootcode -b ${BOOTDIR}/pmbr -p ${BOOTDIR}/gptboot -i 1 ${unit}
+gpart add -t efi -s 2M ${unit}
 gpart add -t freebsd-ufs -l rootfs ${unit}
 
+${TIME} dd if=${EFIESP} of=/dev/${unit}p2 bs=128k
+
 ${TIME} makefs -B little ${TMPIMG} ${FSPROTO}
-${TIME} dd if=${TMPIMG} of=/dev/${unit}p2 bs=128k
+${TIME} dd if=${TMPIMG} of=/dev/${unit}p3 bs=128k
 
 if [ -n "$VERBOSE" ]; then
   set +x


### PR DESCRIPTION
EFI boot requires an EFI SYSTEM PARTITION with an EFI compable boot loader. The Makefile is modified to extract the FreeBSD EFI loader, create a ESP and add the ESP to both the ISO as well as the disk image.
Note that this allows an EFI system to boot into mfsBSD, but due to upstream limitations in FreeBSD, the resulting system will not work. See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=251866.