### PR TITLE
Typo in clean-pkgcache target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -656,7 +656,7 @@ clean-roothack:
 	${_v}${RM} -rf ${WRKDIR}/roothack
 
 clean-pkgcache:
-	${_v}${RM} -rf ${WRKDIR}/cache
+	${_v}${RM} -rf ${WRKDIR}/pkgcache
 
 clean:
 	${_v}if [ -d ${WRKDIR} ]; then \


### PR DESCRIPTION
When the clean-pkgcache target is invoked, it tries to remove
the ${WRKDIR}/cache directory instead of ${WRKDIR}/pkgcache.