### PR TITLE
sshd: allow configuring PermitRootLogin

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -8,7 +8,15 @@ these files to files without .sample ending and make modifications to suit
 your needs.
 
 The default root password is "mfsroot". You can pick a difrerent password
-with the ROOTPW or ROOTPW_HASH make variables.
+with the `ROOTPW` or `ROOTPW_HASH` make variables.
+
+This password can be used to log in as root over SSH.
+
+To disable remote root login, pass `PERMIT_ROOT_LOGIN=no` to make.
+
+To disallow password authentication for root, set
+`PERMIT_ROOT_LOGIN=without-password`. If you do so, remember to add your SSH
+keys to `conf/authorized_keys` if you want to be able to log in via SSH.
 
 ## Additional packages and files
 If you want any packages installed, copy the .tbz files that should be 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ MFSROOT_FREE_INODES?=	10%
 MFSROOT_FREE_BLOCKS?=	10%
 MFSROOT_MAXSIZE?=	120m
 ROOTPW_HASH?=		$$6$$051DdQA7fTvLymkY$$Z5f6snVFQJKugWmGi8y0motBNaKn9em0y2K0ZsJMku3v9gkiYh8M.OTIIie3RvHpzT6udumtZUtc0kXwJcCMR1
+PERMIT_ROOT_LOGIN?=	yes
 
 # If you want to build your own kernel and make you own world, you need to set
 # -DCUSTOM or CUSTOM=1
@@ -439,7 +440,7 @@ ${WRKDIR}/.config_done:
 .elif !empty(ROOTPW_HASH)
 	${_v}echo '${ROOTPW_HASH}'| ${PW} -V ${_DESTDIR}/etc usermod root -H 0
 .endif
-	${_v}echo PermitRootLogin yes >> ${_DESTDIR}/etc/ssh/sshd_config
+	${_v}echo PermitRootLogin ${PERMIT_ROOT_LOGIN} >> ${_DESTDIR}/etc/ssh/sshd_config
 .if exists(${CFGDIR}/hosts)
 	${_v}${INSTALL} -m 0644 ${CFGDIR}/hosts ${_DESTDIR}/etc/hosts
 .elif exists(${CFGDIR}/hosts.sample)


### PR DESCRIPTION
This adds a make variable `PERMIT_ROOT_LOGIN`, which is then used when adding `PermitRootLogin` to `/etc/ssh/sshd_config`.

The default value is set to `yes`, so if the parameter is omitted, the scripts should behave in the same way as before.

Rationale: I am using mfsBSD to remotely install FreeBSD on a dedicated server which is publicly accessible over the internet. To decrease the possibility of someone interfering, I'd like to set up SSH keys-only login, and this allows doing that.