### PR TITLE
Unbreak the build when `ARCH` is not explicitly specified

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 env:
   CIRRUS_CLONE_DEPTH: 1
-  ARCH: amd64
+  TARGET: amd64
 
 build_task:
   timeout_in: 1h

--- a/BUILD.md
+++ b/BUILD.md
@@ -78,7 +78,7 @@ specify the `BUILDWORLD=1` and `BUILDKERNEL=1` variables to `make`, respectively
 5. Custom release edition, i.e., using a FreeBSD release distribution:
 
   ```bash
-  make iso BASE=/cdrom/11.0-RELEASE RELEASE=11.0-RELEASE ARCH=amd64
+  make iso BASE=/cdrom/11.0-RELEASE RELEASE=11.0-RELEASE TARGET=amd64
   ```
 
 6. GCE-compatible .tar.gz file:

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -1,9 +1,25 @@
 #!/bin/sh
+
 set -e
-BASE=/tmp/freebsd-dist
-RELEASE=${RELEASE:-`uname -r`}
-ARCH=$(sysctl -n hw.machine)
-DOWNLOAD_URL=http://ftp.freebsd.org/pub/FreeBSD/releases/${ARCH}/${RELEASE}
+
+vmake()
+{
+	env TARGET=${TARGET} \
+	    TARGET_ARCH=${TARGET_ARCH} \
+	    V=1 \
+	    make "$@"
+}
+
+BASE="${TMPDIR:-/tmp}/freebsd-dist"
+
+# Chop the patch off the release for the running host, e.g.,
+# '14.3-RELEASE-p7' -> '14.3-RELEASE'.
+#
+: "${RELEASE=$(uname -r | sed -Ee 's/-p[[:digit:]]$//')}"
+: "${TARGET=$(uname -m)}"
+: "${TARGET_ARCH=$(uname -p)}"
+DOWNLOAD_URL=http://ftp.freebsd.org/pub/FreeBSD/releases/${TARGET}/${RELEASE}
+
 while getopts b:r: opt
 do
 	case $opt in
@@ -11,8 +27,9 @@ do
 		r) RELEASE="${OPTARG}";;
 	esac
 done
-if [ "${ACTION}" = "prepare" ]
-then
+
+case "${ACTION}" in
+prepare)
 	mkdir -p ${BASE}
 	fetch -m -o ${BASE}/base.txz ${DOWNLOAD_URL}/base.txz
 	fetch -m -o ${BASE}/kernel.txz ${DOWNLOAD_URL}/kernel.txz
@@ -20,28 +37,31 @@ then
 	then
 		cd tools/roothack && make depend && make
 	fi
-elif [ "${ACTION}" = "build-std" ]
-then
-	make clean V=1
-	make iso V=1 RELEASE=${RELEASE} BASE=${BASE} ROOTHACK=1
-	make V=1 RELEASE=${RELEASE} BASE=${BASE} ROOTHACK=1
-elif [ "${ACTION}" = "build-se" ]
-then
-	make clean V=1
-	make iso V=1 RELEASE=${RELEASE} BASE=${BASE} ROOTHCK=1 SE=1
-	make V=1 RELEASE=${RELEASE} BASE=${BASE} ROOTHACK=1 SE=1
-elif [ "${ACTION}" = "build-mini" ]
-then
-	make clean V=1
-	make prepare-mini V=1 RELEASE=${RELEASE} ROOTHACK=1 BASE=${BASE}
-	cd mini
-	make clean V=1
-	make iso V=1 RELEASE=${RELEASE} ROOTHACK=1 BASE=${BASE}
-	make clean V=1
-	cd ..
-	make clean V=1
+	;;
+build-std)
+	vmake clean
+	vmake iso RELEASE=${RELEASE} BASE=${BASE} ROOTHACK=1
+	vmake RELEASE=${RELEASE} BASE=${BASE} ROOTHACK=1
+	;;
+build-se)
+	vmake clean
+	vmake iso RELEASE=${RELEASE} BASE=${BASE} ROOTHACK=1 SE=1
+	vmake RELEASE=${RELEASE} BASE=${BASE} ROOTHACK=1 SE=1
+	;;
+build-mini)
+	vmake clean
+	vmake prepare-mini RELEASE=${RELEASE} ROOTHACK=1 BASE=${BASE}
+	(
+		cd mini
+		vmake clean
+		vmake iso RELEASE=${RELEASE} ROOTHACK=1 BASE=${BASE}
+		vmake clean
+	)
+	vmake clean
 	mv mini/*.iso .
-else
+	;;
+*)
 	echo "Unknown build step"
 	false
-fi
+	;;
+esac

--- a/mini/Makefile
+++ b/mini/Makefile
@@ -9,10 +9,10 @@
 #
 # User-defined variables
 #
-BASEDIR?=${CURDIR}/../work/mfs/rw
-BOOTBASE?=${CURDIR}/../work/disk/boot
-CDBOOTBASE?=${CURDIR}/../work/cdboot
-CFGDIR?=${CURDIR}/conf
+BASEDIR?=${.CURDIR:H}/work/mfs/rw
+BOOTBASE?=${.CURDIR:H}/work/disk/boot
+CDBOOTBASE?=${.CURDIR:H}/work/cdboot
+CFGDIR?=${.CURDIR}/conf
 MFSROOT_FREE_INODES?=5000
 MFSROOT_FREE_BLOCKS?=10%
 MFSROOT_MINSIZE?=80m
@@ -31,7 +31,6 @@ EFILOADER?=	loader_lua.efi
 #
 # Program defaults
 #
-CAT=/bin/cat
 CHFLAGS=/bin/chflags
 CHOWN=/usr/sbin/chown
 CP=/bin/cp
@@ -55,14 +54,16 @@ SYSCTL=/sbin/sysctl
 TAR=/usr/bin/tar
 TOUCH=/usr/bin/touch
 UNAME=/usr/bin/uname
+CAT?=	/bin/cat
+SED?=	/usr/bin/sed
+XARGS?=	/usr/bin/xargs
 #
 BSDLABEL=bsdlabel
 
 #
-CURDIR!=${PWD}
-WRKDIR?=${CURDIR}/tmp
-FILESDIR=${CURDIR}/files
-TOOLSDIR=${CURDIR}/../tools
+WRKDIR?=${.CURDIR}/tmp
+FILESDIR=${.CURDIR}/files
+TOOLSDIR=${.CURDIR:H}/tools
 #
 #
 DOFS=${TOOLSDIR}/doFS.sh
@@ -70,18 +71,27 @@ BOOTMODULES=acpi ahci
 MFSMODULES=geom_mirror geom_nop opensolaris zfs ext2fs smbus ipmi ntfs nullfs tmpfs \
 	aesni crypto cryptodev geom_eli
 #
+
+.if !defined(VERSION)
+# e.g., 14.3-RELEASE
+VERSION!=		${UNAME} -r | ${SED} -Ee 's/-p[[:digit:]]$$//'
+.endif
+# e.g., 14
+_VERSION_MAJOR_VER=	${VERSION:R}
+
+.if defined(ARCH)
+.error "Please use TARGET/TARGET_ARCH instead of ARCH."
+.endif
+
+TARGET?=	${MACHINE_ARCH}
+TARGET_ARCH?=	${MACHINE_CPUARCH}
+
 .if defined(V)
 _v=
 VERB=1
 .else
 _v=@
 VERB=
-.endif
-
-.if !defined(ARCH)
-TARGET!=	${SYSCTL} -n hw.machine_arch
-.else
-TARGET=		${ARCH} 
 .endif
 
 .if !defined(RELEASE)
@@ -134,29 +144,31 @@ rescuelinks: hierarchy ${WRKDIR}/.rescuelinks_done
 ${WRKDIR}/.rescuelinks_done:
 	${_v}echo -n "Installing rescue with linking script ..."
 	${_v}${INSTALL} -m 0555 ${BASEDIR}/rescue/rescue ${_ROOTDIR}/rescue/rescue
-	${_v}for FILE in `cat ${FILESDIR}/rescuelinks`; do \
-		${LN} ${_ROOTDIR}/rescue/rescue ${_ROOTDIR}/$${FILE}; \
-	done
+	${_v}cd ${_ROOTDIR}/rescue && \
+	    ${CAT} ${FILESDIR}/rescuelinks | \
+	    ${XARGS} -n 3 -I % ${LN} -f ./rescue ${_ROOTDIR}/%
 	${_v}${TOUCH} ${WRKDIR}/.rescuelinks_done
 	${_v}echo " done"
 
 installbase: hierarchy rescuelinks ${WRKDIR}/.installbase_done
 ${WRKDIR}/.installbase_done:
 	${_v}echo -n "Installing base files ..."
-	${_v}cd ${_ROOTDIR} && for FILE in `cat ${FILESDIR}/instfiles`; do \
-		${CP} -pP ${BASEDIR}/$${FILE} ${_ROOTDIR}/$${FILE}; \
-	done
-	${_v}cd ${_ROOTDIR} && for DIR in `cat ${FILESDIR}/instdirs`; do \
-		${CP} -a ${BASEDIR}/$${DIR}/ ${_ROOTDIR}/$${DIR}; \
-	done
+	${_v}cd ${_ROOTDIR} && \
+	${_v}cd ${BASEDIR} && \
+	    ${CAT} ${FILESDIR}/instfiles | \
+	    ${XARGS} -n 3 -I % ${CP} -pP ./% ${_ROOTDIR}/%
+	${_v}cd ${BASEDIR} && \
+	    ${CAT} ${FILESDIR}/instdirs | \
+	    ${XARGS} -n 3 -I % ${CP} -a ./% ${_ROOTDIR}/%
 	${_v}${TOUCH} ${WRKDIR}/.installbase_done
 	${_v}echo " done"
 
 basetar: hierarchy rescuelinks ${WRKDIR}/.basetar_done
 ${WRKDIR}/.basetar_done:
 	${_v}echo -n "Creating tar of base libraries and binaries ..."
-	${_v}cd ${BASEDIR} && ${TAR} -cJf ${_ROOTDIR}/.mfs_base.txz \
-	`cat ${FILESDIR}/basedirs` `cat ${FILESDIR}/basefiles` || exit 0
+	${_v}-cd ${BASEDIR} && \
+	${TAR} -cJf ${_ROOTDIR}/.mfs_base.txz \
+	    `${CAT} ${FILESDIR}/basedirs ${FILESDIR}/basefiles`
 	${_v}${TOUCH} ${WRKDIR}/.basetar_done
 	${_v}echo " done"
 
@@ -164,8 +176,9 @@ localtar: hierarchy ${WRKDIR}/.localtar_done
 ${WRKDIR}/.localtar_done:
 .if exists(${FILESDIR}/localfiles)
 	${_v}echo -n "Creating local files tar ..."
-	${_v}cd ${LOCALBASEDIR}/usr/local && ${TAR} -cJf ${_ROOTDIR}/.mfs_local.txz \
-	`cat ${FILESDIR}/localfiles`
+	${_v}cd ${LOCALBASEDIR}/usr/local && \
+	${TAR} -cJf ${_ROOTDIR}/.mfs_local.txz \
+	    `${CAT} ${FILESDIR}/localfiles`
 	${_v}${TOUCH} ${WRKDIR}/.localtar_done
 	${_v}echo " done"
 .endif
@@ -298,7 +311,7 @@ ${GCEFILE}:
 .if !exists(${GTAR})
 	${_v}echo "${GTAR} is missing, please install archivers/gtar first"; exit 1
 .else
-	${_v}${GTAR} -C ${CURDIR} -Szcf ${GCEFILE} --transform='s/${IMAGE}/disk.raw/' ${IMAGE}
+	${_v}${GTAR} -C ${.CURDIR} -Szcf ${GCEFILE} --transform='s/${IMAGE}/disk.raw/' ${IMAGE}
 	${_v}echo " GCE tarball built"
 	${_v}${LS} -l ${GCEFILE}
 .endif
@@ -323,7 +336,7 @@ tar: install config boot mfsroot ${TARFILE}
 ${TARFILE}:
 	${_v}echo -n "Creating tar file ..."
 	${_v}cd ${WRKDIR}/disk && ${FIND} . -depth 1 \
-		-exec ${TAR} -r -f ${CURDIR}/${TARFILE} {} \;
+		-exec ${TAR} -r -f ${.CURDIR}/${TARFILE} {} \;
 	${_v}echo " done"
 	${_v}${LS} -l ${TARFILE}
 

--- a/tools/roothack/Makefile
+++ b/tools/roothack/Makefile
@@ -1,5 +1,3 @@
-.include <bsd.init.mk>
-
 PROG=	roothack
 MAN=
 


### PR DESCRIPTION
The change made in fcb3a13e9621010f1494ba0d68699bafaf883434
helped divorce mfsbsd from several assumptions
associated to OS versions/architectures hardcoded in `/Makefile`, but in
doing so it broke the build as the default values used for `ARCH`,
etc, evaluated to empty values (shell expansions performed like `$(foo)`
are treated like expanded variables in make(1)). This resulted in very
confusing build failures when an assert was hit in bsd.endian.mk
building `main` as `bsd.endian.mk` checks the endianness of the
host/target.

Retire `ARCH` and replace it with `TARGET`/`TARGET_ARCH` to make the
build process more symmetric with upstream FreeBSD and to allow both the
CPU architecture and the architecture itself to be overridden. These
variables default to `MACHINE_ARCH` and `MACHINE_CPUARCH`, respectively,
as they are provided by `make`, instead of doing similar things on the
backend trying to figure out what these details are via uname and sysctl.

This change requires refactoring/shifting around the user configuration
to be below the program configuration. This fixes some of the hardcoded
utility [lack] of pathing introduced in the previous corresponding
change.

While here, remove hardcoded assumptions around the OS version, etc.
This isn't perfect, as it still makes the assumption that the build OS
version is the desired target version in all cases. My build script
scrapes vers.c's information instead for the `CUSTOM` build case and
sets `VERSION`, etc, appropriately. Also, fix the fact that we do not
technically produce patch-release media, by chopping the patch version
off of the `uname -r` reported value.

Closes: #166
Signed-off-by: Enji Cooper <ngie@FreeBSD.org>
Fixes:	fcb3a13 ("introduce architecture independence")