### PR TITLE
Fix iterative builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # If you want to build your own kernel and make you own world, you need to set
 # -DCUSTOM or CUSTOM=1
 #
-# To make buildworld use 
+# To make buildworld use
 # -DCUSTOM -DBUILDWORLD or CUSTOM=1 BUILDWORLD=1
 #
 # To make buildkernel use
@@ -517,8 +517,8 @@ compress-usr: install prune cdboot config genkeys customfiles customscripts boot
 ${WRKDIR}/.compress-usr_done:
 .if defined(NO_ROOTHACK)
 	@echo -n "Compressing usr ..."
-	${_v}${TAR} -c -J -C ${_DESTDIR} -f ${_DESTDIR}/.usr.tar.xz usr 
-	${_v}${RM} -rf ${_DESTDIR}/usr && ${MKDIR} ${_DESTDIR}/usr 
+	${_v}${TAR} -c -J -C ${_DESTDIR} -f ${_DESTDIR}/.usr.tar.xz usr
+	${_v}${RM} -rf ${_DESTDIR}/usr && ${MKDIR} ${_DESTDIR}/usr
 .else
 	@echo -n "Compressing root ..."
 	${_v}${TAR} -c -C ${_ROOTDIR} -f - rw | \

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ ${WRKDIR}/.extract_done:
 		fi \
 	done
 .endif
-	@echo -n "Extracting base and kernel ..."
+	@printf "Extracting base and kernel ..."
 	${_v}${CAT} ${BASEFILE} | ${TAR} --unlink -xpzf - -C ${_DESTDIR}
 .if !defined(FREEBSD9)
 	${_v}${CAT} ${KERNELFILE} | ${TAR} --unlink -xpzf - -C ${_BOOTDIR}
@@ -263,12 +263,12 @@ build: extract ${WRKDIR}/.build_done
 ${WRKDIR}/.build_done:
 .if defined(CUSTOM)
 . if defined(BUILDWORLD)
-	@echo -n "Building world ..."
+	@printf "Building world ..."
 	${_v}cd ${SRC_DIR} && \
 	${BUILDENV} make ${_MAKEJOBS} buildworld
 . endif
 . if defined(BUILDKERNEL)
-	@echo -n "Building kernel KERNCONF=${KERNCONF} ..."
+	@printf "Building kernel KERNCONF=${KERNCONF} ..."
 	${_v}cd ${SRC_DIR} && make ${_MAKEJOBS} buildkernel KERNCONF=${KERNCONF}
 . endif
 .endif
@@ -277,16 +277,16 @@ ${WRKDIR}/.build_done:
 install: destdir build ${WRKDIR}/.install_done
 ${WRKDIR}/.install_done:
 .if defined(CUSTOM)
-	@echo -n "Installing world and kernel KERNCONF=${KERNCONF} ..."
+	@printf "Installing world and kernel KERNCONF=${KERNCONF} ..."
 	${_v}cd ${SRC_DIR} && \
 	${INSTALLENV} make installworld distribution DESTDIR="${_DESTDIR}" && \
 	${INSTALLENV} make installkernel KERNCONF=${KERNCONF} DESTDIR="${_ROOTDIR}"
 .endif
 .if defined(SE)
 . if !defined(CUSTOM) && exists(${BASE}/base.txz) && exists(${BASE}/kernel.txz)
-	@echo -n "Copying base.txz and kernel.txz ..."
+	@printf "Copying base.txz and kernel.txz ..."
 . else
-	@echo -n "Creating base.txz and kernel.txz ..."
+	@printf "Creating base.txz and kernel.txz ..."
 . endif
 	${_v}${MKDIR} ${_DISTDIR}
 . if !defined(NO_ROOTHACK)
@@ -335,7 +335,7 @@ ${WRKDIR}/.install_done:
 prune: install ${WRKDIR}/.prune_done
 ${WRKDIR}/.prune_done:
 .if !defined(NO_PRUNE)
-	@echo -n "Removing selected files from distribution ..."
+	@printf "Removing selected files from distribution ..."
 	${_v}if [ -f "${PRUNELIST}" ]; then \
 		for FILE in `${CAT} ${PRUNELIST}`; do \
 			if [ -n "$${FILE}" ]; then \
@@ -349,7 +349,7 @@ ${WRKDIR}/.prune_done:
 
 cdboot: install prune ${WRKDIR}/.cdboot_done
 ${WRKDIR}/.cdboot_done:
-	@echo -n "Copying out cdboot and EFI loader ..."
+	@printf "Copying out cdboot and EFI loader ..."
 	${_v}${MKDIR} ${WRKDIR}/cdboot
 	${_v}${CP} ${_DESTDIR}/boot/cdboot ${WRKDIR}/cdboot/
 .if defined(LOADER_4TH)
@@ -362,7 +362,7 @@ ${WRKDIR}/.cdboot_done:
 
 packages: install prune cdboot ${WRKDIR}/.packages_done
 ${WRKDIR}/.packages_done:
-	@echo -n "Installing pkgng ..."
+	@printf "Installing pkgng ..."
 .  if !exists(${PKG_STATIC})
 	@echo "pkg-static not found at: ${PKG_STATIC}"
 	${_v}exit 1
@@ -371,7 +371,7 @@ ${WRKDIR}/.packages_done:
 	${_v}${INSTALL} -o root -g wheel -m 0755 ${PKG_STATIC} ${_DESTDIR}/usr/local/sbin/
 	${_v}${LN} -sf pkg-static ${_DESTDIR}/usr/local/sbin/pkg
 	@echo " done"
-	@echo  "Installing user packages ..."
+	@echo "Installing user packages ..."
 	${_v}if [ -f "${TOOLSDIR}/packages" ]; then \
 		_PKGS="${TOOLSDIR}/packages"; \
 		elif [ -f "${TOOLSDIR}/packages.sample" ]; then \
@@ -388,7 +388,7 @@ ${WRKDIR}/.packages_done:
 
 packages-mini: packages ${WRKDIR}/.packages_mini_done
 ${WRKDIR}/.packages_mini_done:
-	@echo  "Installing additional mini packages ..."
+	@echo "Installing additional mini packages ..."
 	${_v}if [ -f "${TOOLSDIR}/packages-mini" ]; then \
 		_PKGS="${TOOLSDIR}/packages-mini"; \
 		elif [ -f "${TOOLSDIR}/packages-mini.sample" ]; then \
@@ -404,7 +404,7 @@ ${WRKDIR}/.packages_mini_done:
 
 config: install ${WRKDIR}/.config_done
 ${WRKDIR}/.config_done:
-	@echo -n "Installing configuration scripts and files ..."
+	@printf "Installing configuration scripts and files ..."
 .for FILE in boot.config loader.conf rc.conf rc.local resolv.conf interfaces.conf ttys
 . if !exists(${CFGDIR}/${FILE}) && !exists(${CFGDIR}/${FILE}.sample)
 	@echo "Missing ${CFGDIR}/${FILE}.sample" && exit 1
@@ -483,7 +483,7 @@ ${WRKDIR}/.config_done:
 
 genkeys: config ${WRKDIR}/.genkeys_done
 ${WRKDIR}/.genkeys_done:
-	@echo -n "Generating SSH host keys ..."
+	@printf "Generating SSH host keys ..."
 	${_v}test -f ${_DESTDIR}/etc/ssh/ssh_host_key || ${SSHKEYGEN} -t rsa1 -b 1024 -f ${_DESTDIR}/etc/ssh/ssh_host_key -N '' > /dev/null 2> /dev/null || true
 	${_v}test -f ${_DESTDIR}/etc/ssh/ssh_host_dsa_key || ${SSHKEYGEN} -t dsa -f ${_DESTDIR}/etc/ssh/ssh_host_dsa_key -N '' > /dev/null 2> /dev/null || true
 	${_v}test -f ${_DESTDIR}/etc/ssh/ssh_host_rsa_key || ${SSHKEYGEN} -t rsa -f ${_DESTDIR}/etc/ssh/ssh_host_rsa_key -N '' > /dev/null
@@ -504,7 +504,7 @@ ${WRKDIR}/.customfiles_done:
 customscripts: config ${WRKDIR}/.customscripts_done
 ${WRKDIR}/.customscripts_done:
 .if exists(${CUSTOMSCRIPTSDIR})
-	@echo -n "Running user scripts ..."
+	@printf "Running user scripts ..."
 	@for SCRIPT in `find ${CUSTOMSCRIPTSDIR} -type f`; do \
 		chmod +x $$SCRIPT; \
 		${CUSTOMSCRIPTENV} $$SCRIPT; \
@@ -516,11 +516,11 @@ ${WRKDIR}/.customscripts_done:
 compress-usr: install prune cdboot config genkeys customfiles customscripts boot efiboot packages ${WRKDIR}/.compress-usr_done
 ${WRKDIR}/.compress-usr_done:
 .if defined(NO_ROOTHACK)
-	@echo -n "Compressing usr ..."
+	@printf "Compressing usr ..."
 	${_v}${TAR} -c -J -C ${_DESTDIR} -f ${_DESTDIR}/.usr.tar.xz usr
 	${_v}${RM} -rf ${_DESTDIR}/usr && ${MKDIR} ${_DESTDIR}/usr
 .else
-	@echo -n "Compressing root ..."
+	@printf "Compressing root ..."
 	${_v}${TAR} -c -C ${_ROOTDIR} -f - rw | \
 	${XZ} ${XZ_FLAGS} -v -c > ${_ROOTDIR}/root.txz
 	${_v}${RM} -rf ${_DESTDIR} && ${MKDIR} ${_DESTDIR}
@@ -537,7 +537,7 @@ ${WRKDIR}/roothack/roothack:
 
 install-roothack: compress-usr roothack ${WRKDIR}/.install-roothack_done
 ${WRKDIR}/.install-roothack_done:
-	@echo -n "Installing roothack ..."
+	@printf "Installing roothack ..."
 	${_v}${MKDIR} -p ${_ROOTDIR}/dev ${_ROOTDIR}/sbin
 	${_v}${INSTALL} -m 555 ${ROOTHACK_FILE} ${_ROOTDIR}/sbin/init
 	${_v}${TOUCH} ${WRKDIR}/.install-roothack_done
@@ -545,7 +545,7 @@ ${WRKDIR}/.install-roothack_done:
 
 boot: install prune cdboot ${WRKDIR}/.boot_done
 ${WRKDIR}/.boot_done:
-	@echo -n "Configuring boot environment ..."
+	@printf "Configuring boot environment ..."
 	${_v}${MKDIR} -p ${WRKDIR}/disk/boot/kernel
 	${_v}${CHOWN} root:wheel ${WRKDIR}/disk
 	${_v}${TAR} -c -X ${KERN_EXCLUDE} -C ${_BOOTDIR}/${KERNDIR} -f - . | ${TAR} -xv -C ${WRKDIR}/disk/boot/kernel -f -
@@ -594,7 +594,7 @@ ${WRKDIR}/.boot_done:
 efiboot: install prune cdboot config genkeys customfiles customscripts boot ${WRKDIR}/.efiboot_done
 ${WRKDIR}/.efiboot_done:
 .if !defined(NO_EFIBOOT)
-	@echo -n "Creating EFI boot image ..."
+	@printf "Creating EFI boot image ..."
 	${_v}${MKDIR} -p ${WRKDIR}/efiroot/EFI/BOOT
 	${_v}${CP} ${WRKDIR}/cdboot/${EFILOADER} ${WRKDIR}/efiroot/EFI/BOOT/BOOTX64.efi
 	${_v}${MAKEFS} -t msdos -s 2048k -o fat_type=12,sectors_per_cluster=1 ${WRKDIR}/cdboot/efiboot.img ${WRKDIR}/efiroot
@@ -608,7 +608,7 @@ mfsroot: install prune cdboot config genkeys customfiles customscripts boot efib
 mfsroot: install prune cdboot config genkeys customfiles customscripts boot efiboot compress-usr packages ${WRKDIR}/.mfsroot_done
 .endif
 ${WRKDIR}/.mfsroot_done:
-	@echo -n "Creating and compressing mfsroot ..."
+	@printf "Creating and compressing mfsroot ..."
 	${_v}${MKDIR} ${WRKDIR}/mnt
 	${_v}${MAKEFS} -t ffs -o label=mfsroot -m ${MFSROOT_MAXSIZE} -f ${MFSROOT_FREE_INODES} -b ${MFSROOT_FREE_BLOCKS} ${WRKDIR}/disk/mfsroot ${_ROOTDIR} > /dev/null
 	${_v}${RM} -rf ${WRKDIR}/mnt
@@ -625,7 +625,7 @@ ${WRKDIR}/.mfsroot_done:
 fbsddist: install prune cdboot config genkeys customfiles customscripts boot efiboot compress-usr packages mfsroot ${WRKDIR}/.fbsddist_done
 ${WRKDIR}/.fbsddist_done:
 .if defined(SE)
-	@echo -n "Copying FreeBSD installation image ..."
+	@printf "Copying FreeBSD installation image ..."
 	${_v}${CP} -rf ${_DISTDIR} ${WRKDIR}/disk/
 	@echo " done"
 .endif
@@ -633,7 +633,7 @@ ${WRKDIR}/.fbsddist_done:
 
 image: install prune cdboot config genkeys customfiles customscripts boot efiboot compress-usr mfsroot fbsddist ${IMAGE}
 ${IMAGE}:
-	@echo -n "Creating image file ..."
+	@printf "Creating image file ..."
 .if defined(BSDPART)
 	${_v}${MKDIR} ${WRKDIR}/mnt ${WRKDIR}/trees/base/boot
 	${_v}${INSTALL} -m 0444 ${WRKDIR}/disk/boot/boot ${WRKDIR}/trees/base/boot/
@@ -648,7 +648,7 @@ ${IMAGE}:
 
 gce: install prune cdboot config genkeys customfiles customscripts boot efiboot compress-usr mfsroot fbsddist ${IMAGE} ${GCEFILE}
 ${GCEFILE}:
-	@echo -n "Creating GCE-compatible tarball..."
+	@printf "Creating GCE-compatible tarball..."
 .if !exists(${GTAR})
 	${_v}echo "${GTAR} is missing, please install archivers/gtar first"; exit 1
 .else
@@ -659,7 +659,7 @@ ${GCEFILE}:
 
 iso: install prune cdboot config genkeys customfiles customscripts boot efiboot compress-usr mfsroot fbsddist ${ISOIMAGE}
 ${ISOIMAGE}:
-	@echo -n "Creating ISO image ..."
+	@printf "Creating ISO image ..."
 .if !defined(NO_EFIBOOT)
 	${_v}${MAKEFS} -t cd9660 -o rockridge,label=mfsBSD \
 	-o bootimage=i386\;${WRKDIR}/cdboot/cdboot,no-emul-boot \
@@ -675,7 +675,7 @@ ${ISOIMAGE}:
 
 tar: install prune cdboot config customfiles customscripts boot efiboot compress-usr mfsroot fbsddist ${TARFILE}
 ${TARFILE}:
-	@echo -n "Creating tar file ..."
+	@printf "Creating tar file ..."
 	${_v}cd ${WRKDIR}/disk && ${FIND} . -depth 1 \
 		-exec ${TAR} -r -f ${.CURDIR}/${TARFILE} {} \;
 	@echo " done"

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ all: image
 
 destdir: ${_DESTDIR} ${_BOOTDIR}
 ${_DESTDIR}:
-	${_v}${MKDIR} ${_DESTDIR} && ${CHOWN} root:wheel ${_DESTDIR}
+	${_v}${MKDIR} ${.TARGET} && ${CHOWN} root:wheel ${.TARGET}
 
 ${_BOOTDIR}:
 	${_v}${MKDIR} ${_BOOTDIR}/kernel ${_BOOTDIR}/modules && ${CHOWN} -R root:wheel ${_BOOTDIR}
@@ -257,7 +257,7 @@ ${WRKDIR}/.extract_done:
 .endif
 	@echo " done"
 .endif
-	${_v}${TOUCH} ${WRKDIR}/.extract_done
+	${_v}${TOUCH} ${.TARGET}
 
 build: extract ${WRKDIR}/.build_done
 ${WRKDIR}/.build_done:
@@ -272,7 +272,7 @@ ${WRKDIR}/.build_done:
 	${_v}cd ${SRC_DIR} && make ${_MAKEJOBS} buildkernel KERNCONF=${KERNCONF}
 . endif
 .endif
-	${_v}${TOUCH} ${WRKDIR}/.build_done
+	${_v}${TOUCH} ${.TARGET}
 
 install: destdir build ${WRKDIR}/.install_done
 ${WRKDIR}/.install_done:
@@ -330,7 +330,7 @@ ${WRKDIR}/.install_done:
 .if defined(WITHOUT_RESCUE)
 	${_v}cd ${_DESTDIR} && ${RM} -rf rescue
 .endif
-	${_v}${TOUCH} ${WRKDIR}/.install_done
+	${_v}${TOUCH} ${.TARGET}
 
 prune: install ${WRKDIR}/.prune_done
 ${WRKDIR}/.prune_done:
@@ -343,7 +343,7 @@ ${WRKDIR}/.prune_done:
 			fi; \
 		done; \
 	fi
-	${_v}${TOUCH} ${WRKDIR}/.prune_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 .endif
 
@@ -357,7 +357,7 @@ ${WRKDIR}/.cdboot_done:
 .else
 	${_v}${CP} ${_DESTDIR}/boot/loader_lua.efi ${WRKDIR}/cdboot/
 .endif
-	${_v}${TOUCH} ${WRKDIR}/.cdboot_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 
 packages: install prune cdboot ${WRKDIR}/.packages_done
@@ -384,7 +384,7 @@ ${WRKDIR}/.packages_done:
 			    PKG_CACHEDIR=${WRKDIR}/pkgcache \
 			    ${XARGS} ${PKG} -r ${_DESTDIR} install; \
 		fi;
-	${_v}${TOUCH} ${WRKDIR}/.packages_done
+	${_v}${TOUCH} ${.TARGET}
 
 packages-mini: packages ${WRKDIR}/.packages_mini_done
 ${WRKDIR}/.packages_mini_done:
@@ -400,7 +400,7 @@ ${WRKDIR}/.packages_mini_done:
 		PKG_CACHEDIR=${WRKDIR}/pkgcache \
 		${PKG} -r ${_DESTDIR} install `${CAT} $${_PKGS}`; \
 		fi;
-	${_v}${TOUCH} ${WRKDIR}/.packages_mini_done
+	${_v}${TOUCH} ${.TARGET}
 
 config: install ${WRKDIR}/.config_done
 ${WRKDIR}/.config_done:
@@ -478,7 +478,7 @@ ${WRKDIR}/.config_done:
 .else
 	@echo "Missing ${CFGDIR}/hosts.sample" && exit 1
 .endif
-	${_v}${TOUCH} ${WRKDIR}/.config_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 
 genkeys: config ${WRKDIR}/.genkeys_done
@@ -489,7 +489,7 @@ ${WRKDIR}/.genkeys_done:
 	${_v}test -f ${_DESTDIR}/etc/ssh/ssh_host_rsa_key || ${SSHKEYGEN} -t rsa -f ${_DESTDIR}/etc/ssh/ssh_host_rsa_key -N '' > /dev/null
 	${_v}test -f ${_DESTDIR}/etc/ssh/ssh_host_ecdsa_key || ${SSHKEYGEN} -t ecdsa -f ${_DESTDIR}/etc/ssh/ssh_host_ecdsa_key -N '' > /dev/null
 	${_v}test -f ${_DESTDIR}/etc/ssh/ssh_host_ed25519_key || ${SSHKEYGEN} -t ed25519 -f ${_DESTDIR}/etc/ssh/ssh_host_ed25519_key -N '' > /dev/null
-	${_v}${TOUCH} ${WRKDIR}/.genkeys_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 
 customfiles: config ${WRKDIR}/.customfiles_done
@@ -497,7 +497,7 @@ ${WRKDIR}/.customfiles_done:
 .if exists(${CUSTOMFILESDIR})
 	@echo "Copying user files ..."
 	${_v}${CP} -afv ${CUSTOMFILESDIR}/ ${_DESTDIR}/
-	${_v}${TOUCH} ${WRKDIR}/.customfiles_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 .endif
 
@@ -509,7 +509,7 @@ ${WRKDIR}/.customscripts_done:
 		chmod +x $$SCRIPT; \
 		${CUSTOMSCRIPTENV} $$SCRIPT; \
 	done
-	${_v}${TOUCH} ${WRKDIR}/.customscripts_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 .endif
 
@@ -525,7 +525,7 @@ ${WRKDIR}/.compress-usr_done:
 	${XZ} ${XZ_FLAGS} -v -c > ${_ROOTDIR}/root.txz
 	${_v}${RM} -rf ${_DESTDIR} && ${MKDIR} ${_DESTDIR}
 .endif
-	${_v}${TOUCH} ${WRKDIR}/.compress-usr_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 
 roothack: ${WRKDIR}/roothack/roothack
@@ -540,7 +540,7 @@ ${WRKDIR}/.install-roothack_done:
 	@printf "Installing roothack ..."
 	${_v}${MKDIR} -p ${_ROOTDIR}/dev ${_ROOTDIR}/sbin
 	${_v}${INSTALL} -m 555 ${ROOTHACK_FILE} ${_ROOTDIR}/sbin/init
-	${_v}${TOUCH} ${WRKDIR}/.install-roothack_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 
 boot: install prune cdboot ${WRKDIR}/.boot_done
@@ -588,7 +588,7 @@ ${WRKDIR}/.boot_done:
 	${_v}${RM} -rf ${_BOOTDIR}/${KERNDIR} ${_BOOTDIR}/*.symbols
 	${_v}${MKDIR} -p ${WRKDIR}/boot
 	${_v}${CP} -p ${_DESTDIR}/boot/pmbr ${_DESTDIR}/boot/gptboot ${WRKDIR}/boot
-	${_v}${TOUCH} ${WRKDIR}/.boot_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 
 efiboot: install prune cdboot config genkeys customfiles customscripts boot ${WRKDIR}/.efiboot_done
@@ -598,7 +598,7 @@ ${WRKDIR}/.efiboot_done:
 	${_v}${MKDIR} -p ${WRKDIR}/efiroot/EFI/BOOT
 	${_v}${CP} ${WRKDIR}/cdboot/${EFILOADER} ${WRKDIR}/efiroot/EFI/BOOT/BOOTX64.efi
 	${_v}${MAKEFS} -t msdos -s 2048k -o fat_type=12,sectors_per_cluster=1 ${WRKDIR}/cdboot/efiboot.img ${WRKDIR}/efiroot
-	${_v}${TOUCH} ${WRKDIR}/.efiboot_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 .endif
 
@@ -619,7 +619,7 @@ ${WRKDIR}/.mfsroot_done:
 	else \
 		${INSTALL} -m 0644 ${CFGDIR}/loader.conf.sample ${WRKDIR}/disk/boot/loader.conf; \
 	fi
-	${_v}${TOUCH} ${WRKDIR}/.mfsroot_done
+	${_v}${TOUCH} ${.TARGET}
 	@echo " done"
 
 fbsddist: install prune cdboot config genkeys customfiles customscripts boot efiboot compress-usr packages mfsroot ${WRKDIR}/.fbsddist_done
@@ -629,7 +629,7 @@ ${WRKDIR}/.fbsddist_done:
 	${_v}${CP} -rf ${_DISTDIR} ${WRKDIR}/disk/
 	@echo " done"
 .endif
-	${_v}${TOUCH} ${WRKDIR}/.fbsddist_done
+	${_v}${TOUCH} ${.TARGET}
 
 image: install prune cdboot config genkeys customfiles customscripts boot efiboot compress-usr mfsroot fbsddist ${IMAGE}
 ${IMAGE}:


### PR DESCRIPTION
### Core Change

Prior to this change, certain build artifacts like `IMAGE`, would not be
rebuilt if the inputs to the `IMAGE` had changed and would not be
removed with the `make clean` target.

This change moves from hardcoded sentinels associated with .PHONY
targets, like `image`, away from the build artifacts they produce,
towards sentinel files, such as `${WRKDIR}/.image_done`.

This change ensures that running `make clean` results in a newly
produced image each time the sentinel is removed.

This common logic was replicated to the rest of the high-level targets,
e.g., `cd`, `gce`, etc.

### Ancillary commits
- Clean up trailing whitespace.
- Replace `echo -n` with `printf` for portability reasons.
- Leverage special variable `.TARGET` in lieu of hardcoded equivalents when possible.