### PR TITLE
Add GitHub Actions CI and update loader configs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+name: mfsBSD Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        freebsd: ['13.5', '14.3', '15.0']
+        script:
+          - build-std
+          - build-se
+          - build-mini
+
+    name: FreeBSD ${{ matrix.freebsd }} / ${{ matrix.script }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build inside FreeBSD VM
+        uses: vmactions/freebsd-vm@v1.3.6
+        with:
+          release: ${{ matrix.freebsd }}
+          usesh: true
+          run: |
+            freebsd-version -kru
+            pkg update -f
+            mkdir -p /tmp/freebsd-dist
+            fetch -o /tmp/freebsd-dist https://download.freebsd.org/ftp/releases/amd64/${{ matrix.freebsd }}-RELEASE/base.txz
+            fetch -o /tmp/freebsd-dist https://download.freebsd.org/ftp/releases/amd64/${{ matrix.freebsd }}-RELEASE/kernel.txz
+            ci/ci.sh -b prepare
+            ci/ci.sh -b ${{ matrix.script }}
+
+      - name: Upload ISO artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: iso-${{ matrix.freebsd }}-${{ matrix.script }}
+          path: "*.iso"
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all ISO artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: dist
+
+      - name: Generate release tag
+        id: date
+        run: |
+          echo "tag=v$(date -u +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2.5.0
+        with:
+          tag_name: ${{ steps.date.outputs.tag }}
+          name: Release ${{ steps.date.outputs.tag }}
+          files: dist/**/*.iso
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/conf/loader.conf.sample
+++ b/conf/loader.conf.sample
@@ -52,3 +52,6 @@ mfs_name="/mfsroot"
 ahci_load="YES"
 vfs.root.mountfrom="ufs:/dev/ufs/mfsroot"
 mfsbsd.autodhcp="YES"
+zfs_load="YES"
+# Support For VirtIO-BLK, like Aliyun
+kern.maxphys="65536"

--- a/mini/Makefile
+++ b/mini/Makefile
@@ -167,7 +167,7 @@ basetar: hierarchy rescuelinks ${WRKDIR}/.basetar_done
 ${WRKDIR}/.basetar_done:
 	${_v}echo -n "Creating tar of base libraries and binaries ..."
 	${_v}-cd ${BASEDIR} && \
-	${TAR} -cJf ${_ROOTDIR}/.mfs_base.txz \
+	${TAR} --ignore-failed-read -cJf ${_ROOTDIR}/.mfs_base.txz \
 	    `${CAT} ${FILESDIR}/basedirs ${FILESDIR}/basefiles`
 	${_v}${TOUCH} ${WRKDIR}/.basetar_done
 	${_v}echo " done"

--- a/mini/conf/loader.conf.sample
+++ b/mini/conf/loader.conf.sample
@@ -2,3 +2,6 @@ mfs_load="YES"
 mfs_type="mfs_root"
 mfs_name="/mfsroot"
 vfs.root.mountfrom="ufs:/dev/ufs/mfsroot"
+zfs_load="YES"
+# Support For VirtIO-BLK, like Aliyun
+kern.maxphys="65536"


### PR DESCRIPTION
Introduces a GitHub Actions workflow for building and releasing ISO images for multiple FreeBSD versions. Updates loader.conf.sample files to enable ZFS and VirtIO-BLK support, and modifies the mini Makefile to ignore failed reads when creating base tarballs.

see alao <https://github.com/FreeBSD-Ask/mfsbsd/actions/runs/20922510075> or <https://github.com/FreeBSD-Ask/mfsbsd/releases/tag/v20260112-141846>

I still recommend using GitHub Pages or a similar approach for real-time distribution to ensure the project’s accessibility. Its advantage lies in supporting IPv6.

This PR is sponsored by the Chinese FreeBSD Community.
