### PR TITLE
Refactor CI workflows and add PR build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,12 @@
-name: mfsBSD Build
+name: mfsBSD Build and Release
 
 on:
   push:
-  pull_request:
-  workflow_dispatch:
+    branches:
+      - master
+    paths-ignore:
+      - '.github/**'
+      - '**/*.md'
 
 jobs:
   build:
@@ -22,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build inside FreeBSD VM
-        uses: vmactions/freebsd-vm@v1.3.6
+        uses: vmactions/freebsd-vm@v1.3.7
         with:
           release: ${{ matrix.freebsd }}
           usesh: true

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,34 @@
+name: mfsBSD Build for PR
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        freebsd: ['13.5', '14.3', '15.0']
+        script:
+          - build-std
+          - build-se
+          - build-mini
+
+    name: FreeBSD ${{ matrix.freebsd }} / ${{ matrix.script }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build inside FreeBSD VM
+        uses: vmactions/freebsd-vm@v1.3.7
+        with:
+          release: ${{ matrix.freebsd }}
+          usesh: true
+          run: |
+            freebsd-version -kru
+            pkg update -f
+            mkdir -p /tmp/freebsd-dist
+            fetch -o /tmp/freebsd-dist https://download.freebsd.org/ftp/releases/amd64/${{ matrix.freebsd }}-RELEASE/base.txz
+            fetch -o /tmp/freebsd-dist https://download.freebsd.org/ftp/releases/amd64/${{ matrix.freebsd }}-RELEASE/kernel.txz
+            ci/ci.sh -b prepare
+            ci/ci.sh -b ${{ matrix.script }}


### PR DESCRIPTION
Updated build.yml to trigger only on master branch pushes and ignore certain paths, and upgraded vmactions/freebsd-vm to v1.3.7. Added pr-build.yml to run builds for pull requests across multiple FreeBSD versions and build scripts.