### PR TITLE
Fix/de-duplicate release workflows

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,12 @@
+---
 env:
   CIRRUS_CLONE_DEPTH: 1
   TARGET: amd64
 
 build_task:
   timeout_in: 1h
+  # Defer to the GHA workflow in this scenario.
+  only_if: $CIRRUS_TAG !=~ 'v[0-9]+\.[0-9]+\.[0-9]+'
   matrix:
     - name: 15.0-RELEASE
       freebsd_instance:
@@ -12,10 +15,10 @@ build_task:
       freebsd_instance:
         image_family: freebsd-14-3
   prepare_script:
-  - ci/ci.sh -b prepare
+    - ci/ci.sh -b prepare
   build_std_script:
-  - ci/ci.sh -b build-std
+    - ci/ci.sh -b build-std
   build_se_script:
-  - ci/ci.sh -b build-se
+    - ci/ci.sh -b build-se
   build_mini_script:
-  - ci/ci.sh -b build-mini
+    - ci/ci.sh -b build-mini

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,14 @@
-name: mfsBSD Build
+---
+name: mfsBSD Release Process
 
-on:
+on:  # yamllint disable-line
+  # Defer to Cirrus CI when dealing with non-release workflows.
   push:
-  pull_request:
+    tags:
+      - "v[0-9]*.[0-9]*.[0-9]*"
   workflow_dispatch:
+    tags:
+      - "v[0-9]*.[0-9]*.[0-9]*"
 
 jobs:
   build:
@@ -15,6 +20,7 @@ jobs:
           - build-std
           - build-se
           - build-mini
+      fail-fast: false
 
     name: FreeBSD ${{ matrix.freebsd }} / ${{ matrix.script }}
 
@@ -29,40 +35,32 @@ jobs:
           run: |
             freebsd-version -kru
             pkg update -f
-            mkdir -p /tmp/freebsd-dist
-            fetch -o /tmp/freebsd-dist https://download.freebsd.org/ftp/releases/amd64/${{ matrix.freebsd }}-RELEASE/base.txz
-            fetch -o /tmp/freebsd-dist https://download.freebsd.org/ftp/releases/amd64/${{ matrix.freebsd }}-RELEASE/kernel.txz
             ci/ci.sh -b prepare
             ci/ci.sh -b ${{ matrix.script }}
 
-      - name: Upload ISO artifacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: iso-${{ matrix.freebsd }}-${{ matrix.script }}
-          path: "*.iso"
+          name: mfsbsd-${{ matrix.freebsd }}-${{ matrix.script }}.iso
+          path: |
+            *.iso
+          if-no-files-found: error
 
   release:
     runs-on: ubuntu-latest
     needs: build
 
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Download all ISO artifacts
+      - name: Download build artifacts
         uses: actions/download-artifact@v7
         with:
           path: dist
 
-      - name: Generate release tag
-        id: date
-        run: |
-          echo "tag=v$(date -u +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
-
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2.5.0
         with:
-          tag_name: ${{ steps.date.outputs.tag }}
-          name: Release ${{ steps.date.outputs.tag }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           files: dist/**/*.iso
           make_latest: true
         env:


### PR DESCRIPTION
Prior to this change GHA release workflows and Cirrus CI workflows were always run. Only run Cirrus CI when not dealing with release tags and only run GHA when dealing with release tags. This ensures that only one workflow process runs, reducing overall compute and artifact retention.

### Testing Done

Tested manually via `workflow_dispatch` using `gh api`, similar to the following:
```
% branch=fix-release-workflows
% repo=ngie-eign/mfsbsd
% workflow_id=$(gh api \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/$repo/actions/workflows | jq '.["workflows"][0]["id"]')
% gh api \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  "/repos/$repo/actions/workflows/$workflow_id/dispatches" \
-f "ref=$branch"
```

### Example Release

* [Workflow run](https://github.com/ngie-eign/mfsbsd/actions/runs/21328793998)
* [Release artifacts](https://github.com/ngie-eign/mfsbsd/releases/tag/fix-release-workflows)