### PR TITLE
Update FreeBSD versions to 15.1 and 14.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        freebsd: ['13.5', '14.3', '15.0']
+        freebsd: ['14.4', '15.1']
         script:
           - build-std
           - build-se
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build inside FreeBSD VM
-        uses: vmactions/freebsd-vm@v1.3.6
+        uses: vmactions/freebsd-vm@v1
         with:
           release: ${{ matrix.freebsd }}
           usesh: true
@@ -57,7 +57,7 @@ jobs:
           path: dist
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2.5.0
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
Upgrade FreeBSD 15.0 -> 15.1 and 14.3 -> 14.4

FreeBSD 13.5 is not available for download from https://download.freebsd.org/releases/amd64/

Allow more recent versions of GitHub Actions to be used by less strict version requirement.

Please release new iso images.